### PR TITLE
Declarative attestation authoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,4 @@ test:
 install: build
 	mkdir -p $(PREFIX)/bin
 	cp ground $(PREFIX)/bin/ground
+	./ground attest

--- a/source/attest.d
+++ b/source/attest.d
@@ -1,0 +1,104 @@
+module attest;
+
+import core.stdc.stdio : stderr, stdout, fputs, fwrite, fprintf, FILE;
+import core.stdc.stdlib : exit;
+import db : ZBuf;
+
+extern (C) {
+    FILE* popen(const(char)* command, const(char)* type);
+    int pclose(FILE* stream);
+}
+
+int handleAttest() {
+    import controls : qntxNodes, attestations;
+
+    if (qntxNodes.length == 0) {
+        fputs("ground attest: no qntx nodes defined\n", stderr);
+        return 0;
+    }
+    if (attestations.length == 0) {
+        fputs("ground attest: no attestations defined\n", stderr);
+        return 0;
+    }
+
+    int posted = 0;
+    int failed = 0;
+
+    foreach (ref node; qntxNodes) {
+        foreach (ref a; attestations) {
+            __gshared ZBuf body_;
+            body_.reset();
+            body_.put(`{"subjects":["`);
+            body_.put(a.subject);
+            body_.put(`"],"predicates":["`);
+            body_.put(a.predicate);
+            body_.put(`"],"contexts":["`);
+            body_.put(a.context);
+            body_.put(`"],"actors":["ground"]`);
+            if (a.attributes.length > 0) {
+                body_.put(`,"attributes":`);
+                body_.put(a.attributes);
+            }
+            body_.put(`}`);
+
+            __gshared ZBuf cmd;
+            cmd.reset();
+            cmd.put("curl -s --connect-timeout 0.4 --max-time 0.4 -o /dev/null -w '%{http_code}' -X POST ");
+            cmd.put(node.url);
+            cmd.put("/api/attestations -H 'Content-Type: application/json' -d '");
+            // Escape single quotes in body for shell
+            foreach (c; body_.slice()) {
+                if (c == '\'') cmd.put("'\"'\"'");
+                else cmd.putChar(c);
+            }
+            cmd.put("' 2>/dev/null");
+            cmd.putChar('\0');
+
+            auto pipe = popen(cmd.ptr(), "r\0".ptr);
+            if (pipe is null) {
+                failed++;
+                continue;
+            }
+
+            __gshared char[8] httpCode = 0;
+            size_t n = 0;
+            while (n < httpCode.length - 1) {
+                auto r = fread(&httpCode[n], 1, 1, pipe);
+                if (r == 0) break;
+                n++;
+            }
+            pclose(pipe);
+
+            // Report
+            fputs("  ", stderr);
+            fputs2(node.url);
+            fputs(" ", stderr);
+            fputs2(a.subject);
+            fputs(" -> ", stderr);
+            if (n >= 3 && httpCode[0] == '2') {
+                fwrite(&httpCode[0], 1, n, stderr);
+                fputs(" ok\n", stderr);
+                posted++;
+            } else if (n == 0) {
+                fputs("unreachable\n", stderr);
+                failed++;
+            } else {
+                fwrite(&httpCode[0], 1, n, stderr);
+                fputs(" failed\n", stderr);
+                failed++;
+            }
+        }
+    }
+
+    fprintf(stderr, "ground attest: %d posted, %d failed\n".ptr, posted, failed);
+    return 0;
+}
+
+private void fputs2(const(char)[] s) {
+    fwrite(s.ptr, 1, s.length, stderr);
+}
+
+private size_t fread(void* ptr, size_t size, size_t nmemb, FILE* stream) {
+    import core.stdc.stdio : fread_ = fread;
+    return fread_(ptr, size, nmemb, stream);
+}

--- a/source/attest.d
+++ b/source/attest.d
@@ -1,12 +1,15 @@
 module attest;
 
 import core.stdc.stdio : stderr, stdout, fputs, fwrite, fprintf, FILE;
-import core.stdc.stdlib : exit;
 import db : ZBuf;
 
 extern (C) {
     FILE* popen(const(char)* command, const(char)* type);
     int pclose(FILE* stream);
+    int mkstemp(char* tmpl);
+    int close(int fd);
+    long write(int fd, const(void)* buf, size_t count);
+    int unlink(const(char)* path);
 }
 
 int handleAttest() {
@@ -41,21 +44,31 @@ int handleAttest() {
             }
             body_.put(`}`);
 
+            // Write body to temp file to avoid shell injection
+            __gshared char[32] tmpPath = "/tmp/ground-attest-XXXXXX\0\0\0\0\0\0\0";
+            // Reset template each iteration
+            foreach (i, c; "/tmp/ground-attest-XXXXXX\0")
+                tmpPath[i] = c;
+
+            auto fd = mkstemp(&tmpPath[0]);
+            if (fd < 0) { failed++; continue; }
+
+            auto bodySlice = body_.slice();
+            write(fd, bodySlice.ptr, bodySlice.length);
+            close(fd);
+
             __gshared ZBuf cmd;
             cmd.reset();
             cmd.put("curl -s --connect-timeout 0.4 --max-time 0.4 -o /dev/null -w '%{http_code}' -X POST ");
             cmd.put(node.url);
-            cmd.put("/api/attestations -H 'Content-Type: application/json' -d '");
-            // Escape single quotes in body for shell
-            foreach (c; body_.slice()) {
-                if (c == '\'') cmd.put("'\"'\"'");
-                else cmd.putChar(c);
-            }
-            cmd.put("' 2>/dev/null");
+            cmd.put("/api/attestations -H 'Content-Type: application/json' -d @");
+            cmd.put(tmpPath[0 .. 25]); // /tmp/ground-attest-XXXXXX
+            cmd.put(" 2>/dev/null");
             cmd.putChar('\0');
 
             auto pipe = popen(cmd.ptr(), "r\0".ptr);
             if (pipe is null) {
+                unlink(&tmpPath[0]);
                 failed++;
                 continue;
             }
@@ -68,6 +81,7 @@ int handleAttest() {
                 n++;
             }
             pclose(pipe);
+            unlink(&tmpPath[0]);
 
             // Report
             fputs("  ", stderr);

--- a/source/controls.d
+++ b/source/controls.d
@@ -73,3 +73,8 @@ import proto : extractProjectFiles;
 private static immutable _projFiles = extractProjectFiles(allParsed);
 static immutable projectFiles = _projFiles.files[0 .. _projFiles.len];
 
+// QNTX nodes and attestations — built at CTFE from qntx/attestation blocks
+import proto : ParsedQntxNode, ParsedAttestation;
+static immutable qntxNodes = allParsed.qntxNodes[0 .. allParsed.qntxNodeCount];
+static immutable attestations = allParsed.attestations[0 .. allParsed.attestationCount];
+

--- a/source/count.d
+++ b/source/count.d
@@ -48,6 +48,10 @@ PbtCounts countPbt(string input) {
             expect(input, pos, '{');
             r.totalProjects++;
             countProject(input, pos, r);
+        } else if (wm.base == "qntx" || wm.base == "attestation") {
+            skipWS(input, pos);
+            expect(input, pos, '{');
+            skipBlock(input, pos);
         }
     }
     return r;

--- a/source/main.d
+++ b/source/main.d
@@ -172,6 +172,10 @@ extern (C) int main(int argc, const(char)** argv) {
         const(char)[] cmd = argv[1][0 .. argLen(argv[1])];
         if (cmd == "shovel")
             return handleShovel(argc, argv);
+        if (cmd == "attest") {
+            import attest : handleAttest;
+            return handleAttest();
+        }
     }
 
     if (isatty(0)) {

--- a/source/proto.d
+++ b/source/proto.d
@@ -73,6 +73,17 @@ struct ParsedEnv {
     ubyte count;
 }
 
+struct ParsedQntxNode {
+    string url;
+}
+
+struct ParsedAttestation {
+    string subject;
+    string predicate;
+    string context;
+    string attributes; // raw JSON
+}
+
 struct ParseResult {
     ParsedScope[pbtCounts.totalScopes + 1] scopes;
     size_t scopeCount;
@@ -84,6 +95,10 @@ struct ParseResult {
     size_t projectCount;
     ParsedEnv[pbtCounts.totalEnvs + 4] envs;
     size_t envCount;
+    ParsedQntxNode[16] qntxNodes;
+    size_t qntxNodeCount;
+    ParsedAttestation[32] attestations;
+    size_t attestationCount;
 }
 
 // --- Flat file list extraction (CTFE) ---
@@ -335,8 +350,16 @@ ParseResult parsePbt(string input) {
             skipWS(input, pos);
             expect(input, pos, '{');
             parseProject(input, pos, result);
+        } else if (wm.base == "qntx") {
+            skipWS(input, pos);
+            expect(input, pos, '{');
+            parseQntx(input, pos, result);
+        } else if (wm.base == "attestation") {
+            skipWS(input, pos);
+            expect(input, pos, '{');
+            parseAttestation(input, pos, result);
         } else {
-            assert(0, "Expected 'scope', 'permission', 'control', or 'project'");
+            assert(0, "Expected 'scope', 'permission', 'control', 'project', 'qntx', or 'attestation'");
         }
     }
     return result;
@@ -785,5 +808,91 @@ ParsedPermission parsePermission(ref string input, ref size_t pos) {
         }
     }
     assert(0, "Unterminated permission block");
+}
+
+void parseQntx(ref string input, ref size_t pos, ref ParseResult result) {
+    while (pos < input.length) {
+        skipWS(input, pos);
+        if (pos >= input.length) break;
+        if (input[pos] == '#') { skipLine(input, pos); continue; }
+        if (input[pos] == '}') { pos++; return; }
+
+        auto key = readWord(input, pos);
+        if (key == "node") {
+            skipWS(input, pos);
+            expect(input, pos, '{');
+            assert(result.qntxNodeCount < result.qntxNodes.length, "QNTX node overflow");
+            result.qntxNodes[result.qntxNodeCount] = parseQntxNode(input, pos);
+            result.qntxNodeCount++;
+        } else {
+            assert(0, "Unknown qntx field — expected 'node'");
+        }
+    }
+    assert(0, "Unterminated qntx block");
+}
+
+ParsedQntxNode parseQntxNode(ref string input, ref size_t pos) {
+    ParsedQntxNode n;
+    while (pos < input.length) {
+        skipWS(input, pos);
+        if (pos >= input.length) break;
+        if (input[pos] == '#') { skipLine(input, pos); continue; }
+        if (input[pos] == '}') { pos++; return n; }
+
+        auto key = readWord(input, pos);
+        skipWS(input, pos);
+        expect(input, pos, ':');
+        skipWS(input, pos);
+        auto val = readValue(input, pos);
+        switch (key) {
+            case "url": n.url = val; break;
+            default: assert(0, "Unknown node field");
+        }
+    }
+    assert(0, "Unterminated node block");
+}
+
+void parseAttestation(ref string input, ref size_t pos, ref ParseResult result) {
+    assert(result.attestationCount < result.attestations.length, "Attestation overflow");
+    ParsedAttestation a;
+    while (pos < input.length) {
+        skipWS(input, pos);
+        if (pos >= input.length) break;
+        if (input[pos] == '#') { skipLine(input, pos); continue; }
+        if (input[pos] == '}') {
+            pos++;
+            result.attestations[result.attestationCount] = a;
+            result.attestationCount++;
+            return;
+        }
+
+        auto key = readWord(input, pos);
+        skipWS(input, pos);
+        expect(input, pos, ':');
+        skipWS(input, pos);
+
+        if (key == "attributes") {
+            // Capture raw JSON block between { and matching }
+            assert(pos < input.length && input[pos] == '{', "Expected '{' for attributes");
+            size_t start = pos;
+            int depth = 0;
+            while (pos < input.length) {
+                if (input[pos] == '{') depth++;
+                else if (input[pos] == '}') { depth--; if (depth == 0) { pos++; break; } }
+                else if (input[pos] == '"') { pos++; while (pos < input.length && input[pos] != '"') pos++; }
+                pos++;
+            }
+            a.attributes = input[start .. pos];
+        } else {
+            auto val = readValue(input, pos);
+            switch (key) {
+                case "subject": a.subject = val; break;
+                case "predicate": a.predicate = val; break;
+                case "context": a.context = val; break;
+                default: assert(0, "Unknown attestation field");
+            }
+        }
+    }
+    assert(0, "Unterminated attestation block");
 }
 

--- a/source/proto.d
+++ b/source/proto.d
@@ -97,7 +97,7 @@ struct ParseResult {
     size_t envCount;
     ParsedQntxNode[16] qntxNodes;
     size_t qntxNodeCount;
-    ParsedAttestation[32] attestations;
+    ParsedAttestation[128] attestations;
     size_t attestationCount;
 }
 

--- a/source/proto_test.d
+++ b/source/proto_test.d
@@ -716,3 +716,45 @@ static assert(mcpBuilt.len == 1);
 static assert(mcpBuilt.items[0].mcpTool == "read_messages");
 static assert(mcpBuilt.items[0].controls[0].mcpArg.value == "Alice");
 static assert(mcpBuilt.items[0].controls[1].mcpArg.value == "Bob");
+
+// --- qntx block + attestation block ---
+
+enum qntxInput = `
+qntx {
+  node {
+    url: "http://localhost:8771"
+  }
+  node {
+    url: "http://localhost:8772"
+  }
+}
+
+attestation {
+  subject: "telegram:chat:1667286968"
+  predicate: "raven:route"
+  context: "project:SBVH"
+  attributes: {
+    "chat_id": 1667286968,
+    "project": "SBVH",
+    "chat_name": "Danilo"
+  }
+}
+
+attestation {
+  subject: "telegram:chat:355422856"
+  predicate: "raven:route"
+  context: "project:SBVH"
+}
+`;
+enum qntxParsed = parsePbt(qntxInput);
+static assert(qntxParsed.qntxNodeCount == 2);
+static assert(qntxParsed.qntxNodes[0].url == "http://localhost:8771");
+static assert(qntxParsed.qntxNodes[1].url == "http://localhost:8772");
+static assert(qntxParsed.attestationCount == 2);
+static assert(qntxParsed.attestations[0].subject == "telegram:chat:1667286968");
+static assert(qntxParsed.attestations[0].predicate == "raven:route");
+static assert(qntxParsed.attestations[0].context == "project:SBVH");
+static assert(qntxParsed.attestations[0].attributes.length > 0);
+static assert(qntxParsed.attestations[1].subject == "telegram:chat:355422856");
+static assert(qntxParsed.attestations[1].predicate == "raven:route");
+static assert(qntxParsed.attestations[1].attributes.length == 0);

--- a/source/stop.d
+++ b/source/stop.d
@@ -283,14 +283,18 @@ int handleStop(const(char)[] input, const(char)[] cwd, const(char)[] sessionId) 
     }
 
     // Check project-scoped deferred messages (from QNTX)
+    // Gate: if cwd is a git repo, only deliver on main/master
     {
-        import deferred : readProjectDeferredMessage, markProjectDelivered;
-        auto projDeferred = readProjectDeferredMessage(db, cwd);
-        if (projDeferred.message !is null) {
-            markProjectDelivered(db, projDeferred.name, projDeferred.projectContext);
-            sqlite3_close(db);
-            writeStopResponseAndNotify(projDeferred.message);
-            return 2;
+        auto branch = getBranch(cwd);
+        if (branch is null || branch == "main" || branch == "master") {
+            import deferred : readProjectDeferredMessage, markProjectDelivered;
+            auto projDeferred = readProjectDeferredMessage(db, cwd);
+            if (projDeferred.message !is null) {
+                markProjectDelivered(db, projDeferred.name, projDeferred.projectContext);
+                sqlite3_close(db);
+                writeStopResponseAndNotify(projDeferred.message);
+                return 2;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `qntx { node { url } }` and `attestation { subject, predicate, context, attributes }` blocks to pbt
- CTFE parser, sizing pass, and static assert tests for both blocks
- `ground attest` subcommand: POSTs all declared attestations to all QNTX nodes (0.4s timeout, fire-and-forget)
- `make install` runs `ground attest` automatically after binary install
- Fix project-scoped deferred delivery: gate on main/master when in a git repo, deliver unconditionally otherwise

## Test plan
- [x] CTFE static assert tests pass for qntx/attestation parsing
- [x] `make install` posts to running nodes (201), skips unreachable nodes fast
- [x] Batch raven:routes attestation accepted by QNTX