### PR TITLE
Add per-phase timing observability

### DIFF
--- a/source/main.d
+++ b/source/main.d
@@ -129,6 +129,20 @@ void printDuration(long t0) {
     fputs("\n", stderr);
 }
 
+// Phase breakdown string — handlers write here, main persists it.
+__gshared char[512] g_phasesBuf = 0;
+__gshared size_t g_phasesLen = 0;
+
+void setPhases(const(char)[] s) {
+    auto n = s.length < g_phasesBuf.length ? s.length : g_phasesBuf.length;
+    foreach (i; 0 .. n) g_phasesBuf[i] = s[i];
+    g_phasesLen = n;
+}
+
+const(char)[] getPhases() {
+    return g_phasesBuf[0 .. g_phasesLen];
+}
+
 void recordTiming(long elapsedUs, const(char)[] hookEvent, const(char)[] project) {
     import db : openDb, sqlite3_exec, sqlite3_prepare_v2, sqlite3_bind_int64,
                     sqlite3_bind_text, sqlite3_step, sqlite3_finalize, sqlite3_close,
@@ -148,10 +162,14 @@ void recordTiming(long elapsedUs, const(char)[] hookEvent, const(char)[] project
     enum migrateProject = "ALTER TABLE timing ADD COLUMN project TEXT\0";
     sqlite3_exec(db, migrateProject.ptr, null, null, null);
 
+    // Migrate: add phases column for per-call breakdown
+    enum migratePhases = "ALTER TABLE timing ADD COLUMN phases TEXT\0";
+    sqlite3_exec(db, migratePhases.ptr, null, null, null);
+
     enum idxTiming = "CREATE INDEX IF NOT EXISTS idx_timing_event_project ON timing(hook_event, project, id)\0";
     sqlite3_exec(db, idxTiming.ptr, null, null, null);
 
-    enum sql = "INSERT INTO timing (duration_us, hook_event, project) VALUES (?1, ?2, ?3)\0";
+    enum sql = "INSERT INTO timing (duration_us, hook_event, project, phases) VALUES (?1, ?2, ?3, ?4)\0";
     sqlite3_stmt* stmt;
     if (sqlite3_prepare_v2(db, sql.ptr, -1, &stmt, null) == SQLITE_OK) {
         sqlite3_bind_int64(stmt, 1, elapsedUs);
@@ -159,6 +177,9 @@ void recordTiming(long elapsedUs, const(char)[] hookEvent, const(char)[] project
             sqlite3_bind_text(stmt, 2, hookEvent.ptr, cast(int) hookEvent.length, SQLITE_TRANSIENT);
         if (project.length > 0)
             sqlite3_bind_text(stmt, 3, project.ptr, cast(int) project.length, SQLITE_TRANSIENT);
+        auto phases = getPhases();
+        if (phases.length > 0)
+            sqlite3_bind_text(stmt, 4, phases.ptr, cast(int) phases.length, SQLITE_TRANSIENT);
         sqlite3_step(stmt);
         sqlite3_finalize(stmt);
     }

--- a/source/posttooluse.d
+++ b/source/posttooluse.d
@@ -3,7 +3,23 @@ module posttooluse;
 import matcher : hasSegment, contains, envSubst;
 import hooks : Control, scopeMatches;
 import parse : extractCommand, extractFilePath, extractToolName, writeJsonString;
-import core.stdc.stdio : stdout, fputs;
+import core.stdc.stdio : stdout, fputs, stderr;
+import db : ZBuf;
+
+void putInt(ref ZBuf buf, long v) {
+    char[20] digits = 0;
+    int dLen = 0;
+    if (v == 0) { digits[0] = '0'; dLen = 1; }
+    else { while (v > 0) { digits[dLen++] = cast(char)('0' + v % 10); v /= 10; } }
+    foreach (i; 0 .. dLen) buf.putChar(digits[dLen - 1 - i]);
+}
+
+void emitProfile(ref ZBuf buf) {
+    import main : setPhases;
+    setPhases(buf.slice());
+    fputs(buf.ptr(), stderr);
+    fputs("\n", stderr);
+}
 
 // Maps a mode character to whether the given tool name matches.
 // r=Read/Glob/Grep/LSP, f=WebFetch/WebSearch, w=Edit/Write/NotebookEdit, x=Bash, m=MCP, a=Agent
@@ -50,16 +66,22 @@ bool postToolUseMatch(const Control c, const(char)[] command, const(char)[] file
 // TODO: extract `tool_response` — the actual result the tool returned (ground only reads tool_input today)
 // TODO: extract `agent_id`, `agent_type` — distinguish subagent tool calls from main session
 int handlePostToolUse(const(char)[] input, const(char)[] cwd, const(char)[] sessionId) {
+    import main : usecNow;
+    auto t0 = usecNow();
+
     auto command = extractCommand(input);
     auto filePath = extractFilePath(input);
     auto toolName = extractToolName(input);
     auto detail = command !is null ? command : (filePath !is null ? filePath : cast(const(char)[])"PostToolUse");
+
+    auto tParse = usecNow();
 
     // Check PostToolUse controls (msg-only fire once per session)
     {
         import controls : postToolUseScopes;
         import db : openDb, attestationExists, sqlite3_close;
         auto db = openDb();
+        auto tDb = usecNow();
 
         foreach (ref scope_; postToolUseScopes) {
             if (!scopeMatches(scope_, cwd)) continue;
@@ -76,6 +98,16 @@ int handlePostToolUse(const(char)[] input, const(char)[] cwd, const(char)[] sess
                 }
                 if (db !is null) sqlite3_close(db);
 
+                auto tFire = usecNow();
+                __gshared ZBuf prof;
+                prof.reset();
+                prof.put("parse="); putInt(prof, tParse-t0);
+                prof.put("us db="); putInt(prof, tDb-tParse);
+                prof.put("us match+fire="); putInt(prof, tFire-tDb);
+                prof.put("us total="); putInt(prof, tFire-t0);
+                prof.put("us exit=control");
+                emitProfile(prof);
+
                 fputs(`{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"`, stdout);
                 writeJsonString(envSubst(c.msg.value, cwd));
                 fputs(`"}}`, stdout);
@@ -84,44 +116,57 @@ int handlePostToolUse(const(char)[] input, const(char)[] cwd, const(char)[] sess
             }
         }
         if (db !is null) sqlite3_close(db);
-    }
 
-    // Check deferred PostToolUse controls
-    {
-        import controls : postToolUseDeferredScopes;
-        foreach (ref scope_; postToolUseDeferredScopes) {
-            if (!scopeMatches(scope_, cwd)) continue;
-            foreach (ref c; scope_.controls) {
-                if (c.cmd.len == 0) continue;
-                bool cmdFound = false;
-                foreach (ref v; c.cmd.values)
-                    if (hasSegment(detail, v)) { cmdFound = true; break; }
-                if (!cmdFound) continue;
-                if (c.trigger.len > 0) {
-                    bool triggerHit = false;
-                    foreach (ref v; c.trigger.values)
-                        if (contains(detail, v)) { triggerHit = true; break; }
-                    if (!triggerHit) continue;
+        auto tControls = usecNow();
+
+        // Check deferred PostToolUse controls
+        {
+            import controls : postToolUseDeferredScopes;
+            foreach (ref scope_; postToolUseDeferredScopes) {
+                if (!scopeMatches(scope_, cwd)) continue;
+                foreach (ref c; scope_.controls) {
+                    if (c.cmd.len == 0) continue;
+                    bool cmdFound = false;
+                    foreach (ref v; c.cmd.values)
+                        if (hasSegment(detail, v)) { cmdFound = true; break; }
+                    if (!cmdFound) continue;
+                    if (c.trigger.len > 0) {
+                        bool triggerHit = false;
+                        foreach (ref v; c.trigger.values)
+                            if (contains(detail, v)) { triggerHit = true; break; }
+                        if (!triggerHit) continue;
+                    }
+
+                    import db : openDb, sqlite3_close;
+                    import deferred : writeDeferredMessage;
+                    auto ddb = openDb();
+                    if (ddb is null) continue;
+
+                    auto delay = c.defer.delayFn !is null
+                        ? c.defer.delayFn(cwd)
+                        : c.defer.delaySec;
+                    writeDeferredMessage(ddb, c.name, cwd, sessionId, c.defer.msg, delay);
+
+                    {
+                        import db : attestControlFire;
+                        attestControlFire(ddb, "GroundedPostToolUseDeferred", c.name, cwd, sessionId);
+                    }
+
+                    sqlite3_close(ddb);
                 }
-
-                import db : openDb, sqlite3_close;
-                import deferred : writeDeferredMessage;
-                auto db = openDb();
-                if (db is null) continue;
-
-                auto delay = c.defer.delayFn !is null
-                    ? c.defer.delayFn(cwd)
-                    : c.defer.delaySec;
-                writeDeferredMessage(db, c.name, cwd, sessionId, c.defer.msg, delay);
-
-                {
-                    import db : attestControlFire;
-                    attestControlFire(db, "GroundedPostToolUseDeferred", c.name, cwd, sessionId);
-                }
-
-                sqlite3_close(db);
             }
         }
+
+        auto tDeferred = usecNow();
+        __gshared ZBuf prof;
+        prof.reset();
+        prof.put("parse="); putInt(prof, tParse-t0);
+        prof.put("us db="); putInt(prof, tDb-tParse);
+        prof.put("us controls="); putInt(prof, tControls-tDb);
+        prof.put("us deferred="); putInt(prof, tDeferred-tControls);
+        prof.put("us total="); putInt(prof, tDeferred-t0);
+        prof.put("us exit=none");
+        emitProfile(prof);
     }
 
     return 0;

--- a/source/pretooluse.d
+++ b/source/pretooluse.d
@@ -2,7 +2,23 @@ module pretooluse;
 
 import matcher : checkAllCommands, applyArg, applyOmit, indexOf, contains, hasSegment, Buf, envSubst;
 import parse : extractCommand, extractToolName, extractFilePath, extractToolUseId, writeJsonString, fputs2;
-import core.stdc.stdio : stdout, fputs, fwrite;
+import core.stdc.stdio : stdout, fputs, fwrite, stderr, fprintf;
+import db : ZBuf;
+
+void emitProfile(ref ZBuf buf) {
+    import main : setPhases;
+    setPhases(buf.slice());
+    fputs(buf.ptr(), stderr);
+    fputs("\n", stderr);
+}
+
+void putInt(ref ZBuf buf, long v) {
+    char[20] digits = 0;
+    int dLen = 0;
+    if (v == 0) { digits[0] = '0'; dLen = 1; }
+    else { while (v > 0) { digits[dLen++] = cast(char)('0' + v % 10); v /= 10; } }
+    foreach (i; 0 .. dLen) buf.putChar(digits[dLen - 1 - i]);
+}
 
 // Advisory controls inject context without overriding permission prompts.
 // Only explicit "ask" or "deny" should be sent as permissionDecision.
@@ -67,11 +83,17 @@ void writeResponse(const(char)[] command, const(char)[] context, const(char)[] d
 // TODO: extract `agent_id`, `agent_type` — gate subagent tool calls differently from main session
 // TODO: extract `permission_mode` — adjust decisions based on current mode (plan, auto, etc.)
 int handlePreToolUse(const(char)[] input, const(char)[] cwd, const(char)[] sessionId) {
+    import main : usecNow;
+    auto t0 = usecNow();
+    long tParse, tBinary, tMatch, tDb, tPerm;
+
     auto toolName = extractToolName(input);
     auto toolUseId = extractToolUseId(input);
     if (toolUseId is null) toolUseId = "unknown";
 
     auto command = extractCommand(input);
+
+    tParse = usecNow();
 
     if (command !is null) {
         // Make sessionId available to check handlers (e.g. commitNotRequested)
@@ -83,7 +105,7 @@ int handlePreToolUse(const(char)[] input, const(char)[] cwd, const(char)[] sessi
             import binary : checkGitAddForBinary;
             auto binaryFile = checkGitAddForBinary(command, cwd);
             if (binaryFile !is null) {
-                import db : openDb, attestEvent, sqlite3_close, ZBuf;
+                import db : openDb, attestEvent, sqlite3_close;
                 auto db = openDb();
                 if (db !is null) {
                     __gshared ZBuf attrs;
@@ -104,11 +126,14 @@ int handlePreToolUse(const(char)[] input, const(char)[] cwd, const(char)[] sessi
             }
         }
 
+        tBinary = usecNow();
+
         // Bash — check controls
         auto results = checkAllCommands(command, cwd);
+        tMatch = usecNow();
 
         if (results.count > 0) {
-            import db : openDb, attestationExists, attestEvent, sqlite3_close, ZBuf;
+            import db : openDb, attestationExists, attestEvent, sqlite3_close;
             auto db = openDb();
 
             const(char)[] finalDecision;
@@ -181,6 +206,18 @@ int handlePreToolUse(const(char)[] input, const(char)[] cwd, const(char)[] sessi
             }
 
             if (db !is null) sqlite3_close(db);
+            tDb = usecNow();
+
+            __gshared ZBuf prof;
+            prof.reset();
+            prof.put("parse="); putInt(prof, tParse-t0);
+            prof.put("us binary="); putInt(prof, tBinary-tParse);
+            prof.put("us match="); putInt(prof, tMatch-tBinary);
+            prof.put("us db="); putInt(prof, tDb-tMatch);
+            prof.put("us total="); putInt(prof, tDb-t0);
+            if (hasDeny) prof.put("us exit=deny");
+            else prof.put("us exit=control");
+            emitProfile(prof);
 
             if (hasDeny) {
                 writeDenyResponse(allMessages.slice());
@@ -209,10 +246,30 @@ int handlePreToolUse(const(char)[] input, const(char)[] cwd, const(char)[] sessi
                     if (seg.length > 0) {
                         auto permResult = evaluatePermission(permissionScopes, cwd, toolName, seg);
                         if (permResult.decision == Decision.deny) {
+                            tPerm = usecNow();
+                            __gshared ZBuf prof;
+                            prof.reset();
+                            prof.put("parse="); putInt(prof, tParse-t0);
+                            prof.put("us binary="); putInt(prof, tBinary-tParse);
+                            prof.put("us match="); putInt(prof, tMatch-tBinary);
+                            prof.put("us perm="); putInt(prof, tPerm-tMatch);
+                            prof.put("us total="); putInt(prof, tPerm-t0);
+                            prof.put("us exit=perm-deny");
+                            emitProfile(prof);
                             writeDenyResponse(permResult.msg);
                             return 0;
                         }
                         if (permResult.decision == Decision.allow) {
+                            tPerm = usecNow();
+                            __gshared ZBuf prof;
+                            prof.reset();
+                            prof.put("parse="); putInt(prof, tParse-t0);
+                            prof.put("us binary="); putInt(prof, tBinary-tParse);
+                            prof.put("us match="); putInt(prof, tMatch-tBinary);
+                            prof.put("us perm="); putInt(prof, tPerm-tMatch);
+                            prof.put("us total="); putInt(prof, tPerm-t0);
+                            prof.put("us exit=perm-allow");
+                            emitProfile(prof);
                             writeResponse(command, "", "allow");
                             return 0;
                         }
@@ -227,6 +284,18 @@ int handlePreToolUse(const(char)[] input, const(char)[] cwd, const(char)[] sessi
             }
         }
 
+        tPerm = usecNow();
+        {
+            __gshared ZBuf prof;
+            prof.reset();
+            prof.put("parse="); putInt(prof, tParse-t0);
+            prof.put("us binary="); putInt(prof, tBinary-tParse);
+            prof.put("us match="); putInt(prof, tMatch-tBinary);
+            prof.put("us perm="); putInt(prof, tPerm-tMatch);
+            prof.put("us total="); putInt(prof, tPerm-t0);
+            prof.put("us exit=bash-none");
+            emitProfile(prof);
+        }
         return 0;
     }
 
@@ -256,7 +325,7 @@ int handlePreToolUse(const(char)[] input, const(char)[] cwd, const(char)[] sessi
         import controls : allScopes;
         import hooks : scopeMatches;
         import parse : extractToolInputRegion;
-        import db : openDb, attestationExists, attestEvent, sqlite3_close, ZBuf;
+        import db : openDb, attestationExists, attestEvent, sqlite3_close;
 
         auto db = openDb();
         __gshared Buf mcpMsgBuf;
@@ -305,7 +374,7 @@ int handlePreToolUse(const(char)[] input, const(char)[] cwd, const(char)[] sessi
     if (filePath !is null) {
         import controls : allScopes;
         import hooks : scopeMatches;
-        import db : openDb, attestationExists, attestEvent, sqlite3_close, ZBuf;
+        import db : openDb, attestationExists, attestEvent, sqlite3_close;
 
         auto db = openDb();
         __gshared Buf fileMsgBuf;
@@ -341,6 +410,16 @@ int handlePreToolUse(const(char)[] input, const(char)[] cwd, const(char)[] sessi
             writeContextResponse(fileMsgBuf.slice(), advisoryDecision(fileDecision));
             return 0;
         }
+    }
+
+    auto tEnd = usecNow();
+    {
+        __gshared ZBuf prof;
+        prof.reset();
+        prof.put("parse="); putInt(prof, tParse-t0);
+        prof.put("us total="); putInt(prof, tEnd-t0);
+        prof.put("us exit=none");
+        emitProfile(prof);
     }
     return 0;
 }

--- a/source/stop.d
+++ b/source/stop.d
@@ -290,6 +290,8 @@ int handleStop(const(char)[] input, const(char)[] cwd, const(char)[] sessionId) 
         }
     }
 
+    auto tDeferSess = usecNow();
+
     // Check project-scoped deferred messages (from QNTX)
     // Gate: if cwd is a git repo, only deliver on main/master
     {
@@ -373,7 +375,11 @@ int handleStop(const(char)[] input, const(char)[] cwd, const(char)[] sessionId) 
                         putInt(timingMsg, (t5-t4)/1000);
                         timingMsg.put("ms deferred=");
                         putInt(timingMsg, (t6-t5)/1000);
-                        timingMsg.put("ms timing=");
+                        timingMsg.put("ms(sessQ=");
+                        putInt(timingMsg, (tDeferSess-t5)/1000);
+                        timingMsg.put("ms projQ=");
+                        putInt(timingMsg, (t6-tDeferSess)/1000);
+                        timingMsg.put("ms) timing=");
                         putInt(timingMsg, (t7-t6)/1000);
                         timingMsg.put("ms]");
                         attestEvent(db, "GroundedStop", cwd, sessionId, `{"control":"timing-regression"}`);
@@ -389,11 +395,30 @@ int handleStop(const(char)[] input, const(char)[] cwd, const(char)[] sessionId) 
 
     auto t7 = usecNow();
 
-    fprintf(stderr, "STOP-PROFILE parse=%ldus db=%ldus trail=%ldus[branch=%ldus rust=%d rsQ=%ldus remQ=%ldus clipQ=%ldus skip=%d] triggers=%ldus deliver=%ldus deferred=%ldus timing=%ldus total=%ldus\n".ptr,
-        t1-t0, t2-t1, t3-t2, branchUs, cast(int)trailTiming.isRust,
-        trailTiming.rsQueryUs, trailTiming.reminderQueryUs, trailTiming.clippyQueryUs,
-        cast(int)trailTiming.skippedEarly,
-        t4-t3, t5-t4, t6-t5, t7-t6, t7-t0);
+    // Build phases string for persistence and stderr
+    {
+        import main : setPhases;
+        __gshared ZBuf prof;
+        prof.reset();
+        prof.put("parse="); putInt(prof, t1-t0);
+        prof.put("us db="); putInt(prof, t2-t1);
+        prof.put("us trail="); putInt(prof, t3-t2);
+        prof.put("us(branch="); putInt(prof, branchUs);
+        prof.put("us rsQ="); putInt(prof, trailTiming.rsQueryUs);
+        prof.put("us remQ="); putInt(prof, trailTiming.reminderQueryUs);
+        prof.put("us clipQ="); putInt(prof, trailTiming.clippyQueryUs);
+        prof.put("us) triggers="); putInt(prof, t4-t3);
+        prof.put("us deliver="); putInt(prof, t5-t4);
+        prof.put("us deferred="); putInt(prof, t6-t5);
+        prof.put("us(sessQ="); putInt(prof, tDeferSess-t5);
+        prof.put("us projQ="); putInt(prof, t6-tDeferSess);
+        prof.put("us) timing="); putInt(prof, t7-t6);
+        prof.put("us total="); putInt(prof, t7-t0);
+        prof.put("us");
+        setPhases(prof.slice());
+        fputs(prof.ptr(), stderr);
+        fputs("\n", stderr);
+    }
 
     sqlite3_close(db);
     return 0;


### PR DESCRIPTION
## Summary
- PreToolUse, PostToolUse, Stop now record per-phase microsecond breakdowns
- New `phases` TEXT column in timing table persists the breakdown alongside `duration_us`
- Stop's deferred phase split into `sessQ` and `projQ` sub-timings

## Evidence
```
438|parse=5us db=6288us triggers=30478us deferred=265327us(sessQ=256553us projQ=8774us) timing=10534us total=312752us
```
sessQ (deferred session query) is the dominant contributor to Stop spikes, with triggers and timing stacking on top.

## Test plan
- [x] `make build` compiles clean
- [x] `make install` runs, phases column migrated
- [x] Verified phases data flowing into db across PreToolUse, PostToolUse, Stop
- [ ] CI passes