### PR TITLE
exec: run scripts on hook events, deliver output via watch, ERROR AXIOM enforced

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,3 +11,13 @@ Read COUNTDOWN.md for project status.
 Read bench.fish for CTFE scaling limits.
 
 TEST DRIVEN DEVELOPMENT (TDD): write a failing test before implementing. Confirm it fails, then Green: Write code that makes the test pass.
+
+## ERROR AXIOM
+
+An **ERROR** is a first-class primitive. A typed value that crosses
+every layer of the system unchanged. an `Error` is the entity
+any layer emits when something goes wrong.
+
+*The ERROR is a sacred first-class citizen, never collapsed, dropped,
+swallowed or suppressed; they land in front of the user, contextually,
+at the exact point of interaction.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,19 @@
 Read source/hooks.d for control types, scope struct, and trigger builders.
+  - ERROR AXIOM Not Conformant yet. Remove this line when done
 Read source/strop.d for value-shape validation on extracted flag values.
+  - ERROR AXIOM Not Conformant yet. Remove this line when done
 Read source/controls.d for CTFE wiring — how pbt becomes static immutable scope arrays.
+  - ERROR AXIOM Not Conformant yet. Remove this line when done
 Read source/control_handlers.d for check, delay, and deliver handler implementations.
+  - ERROR AXIOM Not Conformant yet. Remove this line when done
 Read source/deferred.d for deferred delivery — session-scoped and project-scoped messages delivered at Stop.
+  - ERROR AXIOM Not Conformant yet. Remove this line when done
 Read source/immediate.d for immediate delivery — attestation format for external writers (QNTX, etc).
+  - ERROR AXIOM Not Conformant yet. Remove this line when done
 Read source/watch.d for the asyncRewake watcher — how immediate messages reach running sessions.
+  - ERROR AXIOM Not Conformant yet. Remove this line when done
+Read source/exec.d for exec dispatch — fork+pipe+wrapper, stdout/stderr capture, timeout.
+Read source/errors.d for the GroundError primitive and deliverError fallback chain (db → breadcrumb → stderr).
 Read README.md for project overview.
 Read COUNTDOWN.md for project status.
 

--- a/source/db.d
+++ b/source/db.d
@@ -536,6 +536,48 @@ void attestControlFire(sqlite3* db, const(char)[] predicate, const(char)[] contr
     if (ownDb) sqlite3_close(db);
 }
 
+// Exec-fire attestation keyed on (control, session, tool_use_id). Dedup at
+// tool-call granularity — each Claude Code tool call has a unique
+// tool_use_id, so repeated PostToolUse invocations for the same tool call
+// see the fire and skip. Distinct tool calls each fire once.
+void attestExecFire(sqlite3* db, const(char)[] controlName, const(char)[] cwd,
+                    const(char)[] sessionId, const(char)[] toolUseId) {
+    __gshared ZBuf efAttrs;
+    efAttrs.reset();
+    efAttrs.put(`{"control":"`);
+    efAttrs.put(controlName);
+    efAttrs.put(`","tool_use_id":"`);
+    efAttrs.put(toolUseId);
+    efAttrs.put(`"}`);
+
+    bool ownDb = db is null;
+    if (ownDb) {
+        db = openDb();
+        if (db is null) return;
+    }
+    attestEvent(db, "GroundedExec", cwd, sessionId, efAttrs.slice());
+    if (ownDb) sqlite3_close(db);
+}
+
+bool execFireExists(sqlite3* db, const(char)[] controlName,
+                    const(char)[] sessionId, const(char)[] toolUseId) {
+    __gshared ZBuf ctx;
+    ctx.reset();
+    ctx.put("session:");
+    ctx.put(sessionId);
+
+    enum sql = "SELECT 1 FROM attestations WHERE json_extract(predicates, '$[0]') = 'GroundedExec' AND json_extract(attributes, '$.control') = ?1 AND json_extract(attributes, '$.tool_use_id') = ?2 AND json_extract(contexts, '$[0]') = ?3 LIMIT 1\0";
+    sqlite3_stmt* stmt;
+    if (sqlite3_prepare_v2(db, sql.ptr, -1, &stmt, null) != SQLITE_OK)
+        return false;
+    sqlite3_bind_text(stmt, 1, controlName.ptr, cast(int) controlName.length, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 2, toolUseId.ptr, cast(int) toolUseId.length, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 3, ctx.ptr(), cast(int) ctx.len, SQLITE_TRANSIENT);
+    bool found = sqlite3_step(stmt) == SQLITE_ROW;
+    sqlite3_finalize(stmt);
+    return found;
+}
+
 // --- Type attestation ---
 // Attests a type definition so QNTX knows what to do with the data.
 // ID encodes version — re-attested when ground updates. INSERT OR IGNORE prevents duplicates.

--- a/source/db.d
+++ b/source/db.d
@@ -10,6 +10,7 @@ struct sqlite3;
 struct sqlite3_stmt;
 
 enum SQLITE_OK = 0;
+enum SQLITE_BUSY = 5;
 enum SQLITE_ROW = 100;
 enum SQLITE_DONE = 101;
 enum SQLITE_TRANSIENT = cast(void function(void*)) -1;
@@ -77,6 +78,12 @@ sqlite3* openStandaloneDb() {
     // Disable auto-checkpoint — explicit checkpoints in SessionStart/PreCompact only.
     // Prevents random 1-2s stalls when WAL crosses 4MB threshold on a large db.
     sqlite3_exec(db, "PRAGMA wal_autocheckpoint = 0\0".ptr, null, null, null);
+
+    // 5s busy timeout — SQLite handles retries internally on lock
+    // contention rather than immediately returning SQLITE_BUSY. Necessary
+    // for exec wrappers to reliably persist their result rows when the
+    // main ground hook + watch + other wrappers are all writing.
+    sqlite3_exec(db, "PRAGMA busy_timeout = 5000\0".ptr, null, null, null);
 
     // Create table if needed
     enum schema = "CREATE TABLE IF NOT EXISTS attestations ("

--- a/source/errors.d
+++ b/source/errors.d
@@ -1,0 +1,237 @@
+module errors;
+
+// The ERROR AXIOM (CLAUDE.md): an Error is a first-class primitive, a
+// typed value that crosses every layer of the system unchanged. Never
+// collapsed, dropped, swallowed, or suppressed. Lands in front of the
+// user, contextually, at the exact point of interaction.
+//
+// This module defines the typed Error and the delivery contract that
+// satisfies "never dropped." Any code that would previously `return`
+// silently on failure must instead construct a GroundError and call
+// deliverError. The delivery function tries the primary channel and
+// falls back through progressively cheaper channels until one succeeds.
+// If ALL fail, that itself is a bug — never a swallow.
+
+struct GroundError {
+    string origin;       // e.g. "exec.mkstemp", "exec.wrapper.write", "exec.script"
+    string message;      // human-readable description
+    int    errnoVal;     // OS errno, 0 when not applicable
+    int    exitCode;     // -1 when not applicable
+    string sessionId;    // routing to the session that triggered
+    string controlName;  // which control produced the Error
+    string toolUseId;    // tool call that triggered
+    long   timestamp;    // unix seconds
+    string stdout;       // captured stdout (may be empty)
+    string stderr;       // captured stderr (may be empty) — primary error content
+}
+
+extern (C) {
+    int open(const(char)* path, int flags, uint mode);
+    long write(int fd, const(void)* buf, size_t count);
+    int close(int fd);
+    int mkdir(const(char)* path, uint mode);
+}
+
+enum O_WRONLY = 1;
+enum O_CREAT  = 0x0200; // macOS
+enum O_APPEND = 8;
+enum STDERR_FD = 2;
+
+// Deliver an Error through progressively cheaper channels. Returns the
+// name of the channel that succeeded, or empty if ALL channels failed
+// (which is itself a bug per the axiom — caller should log this too).
+//
+// Channel order:
+//   1. Primary: immediate:exec-result attestation via db → watch → session.
+//      Structured, styled delivery. Requires db + watch both healthy.
+//   2. Fallback 1: append to ~/.local/share/ground/errors/<session>.log.
+//      Survives db outages. Watch can be extended to pick these up.
+//   3. Fallback 2: write to stderr (fd 2). If ground was invoked by a
+//      hook and stderr is still open, Claude Code will render it. If
+//      the process was orphaned, likely goes nowhere — but still tried.
+//
+// The intent: SOMETHING succeeds. If none do, the calling site is
+// responsible for its own diagnostic (e.g. abort with a message).
+const(char)[] deliverError(const ref GroundError err) {
+    // Primary: db write. writeExecResult retries on SQLITE_BUSY and
+    // returns true only if the row was persisted. If it returns false
+    // (retries exhausted, or non-busy step error), we escalate.
+    {
+        import db : openDb, sqlite3_close;
+        import immediate : writeExecResult;
+        auto db = openDb();
+        if (db !is null) {
+            auto result = formatResult(err);
+            auto ok = writeExecResult(db, err.sessionId, err.controlName, result, err.stdout, err.stderr);
+            sqlite3_close(db);
+            if (ok) return "db";
+        }
+    }
+
+    // Fallback 1: filesystem breadcrumb. Append to a per-session error log.
+    if (writeBreadcrumb(err)) return "breadcrumb";
+
+    // Fallback 2: stderr. May or may not reach anywhere, but tried.
+    if (writeStderr(err)) return "stderr";
+
+    // ALL channels failed — the axiom is violated at this level. The
+    // caller must handle (e.g. abort loudly). We return empty so the
+    // caller knows nothing landed.
+    return "";
+}
+
+// Format an Error into the compact result string used by the primary
+// delivery path. Shape mirrors the exec-result convention:
+//   "exit <N>"                         — script ran and exited
+//   "start-failed <origin> errno <N>"  — pre-execv failure
+//   "<origin>: <message>"              — anything else (timeout, etc.)
+//
+// Uses a shared static buffer — no GC, no allocations. Caller must copy
+// the returned slice before the next call if it needs to retain it.
+private const(char)[] formatResult(const ref GroundError err) {
+    __gshared char[256] buf = 0;
+    size_t pos = 0;
+
+    void appendStr(const(char)[] s) {
+        foreach (c; s) { if (pos < buf.length - 1) buf[pos++] = c; }
+    }
+    void appendInt(long v) {
+        if (v == 0) { appendStr("0"); return; }
+        bool neg = v < 0;
+        if (neg) v = -v;
+        char[24] nb = 0;
+        int nl = 0;
+        while (v > 0 && nl < 23) { nb[nl++] = cast(char)('0' + v % 10); v /= 10; }
+        if (neg) appendStr("-");
+        foreach_reverse (i; 0 .. nl) { if (pos < buf.length - 1) buf[pos++] = nb[i]; }
+    }
+
+    if (err.exitCode >= 0) {
+        appendStr("exit ");
+        appendInt(cast(long) err.exitCode);
+    } else if (err.errnoVal != 0) {
+        appendStr("start-failed ");
+        appendStr(err.origin);
+        appendStr(" errno ");
+        appendInt(cast(long) err.errnoVal);
+    } else {
+        appendStr(err.origin);
+        appendStr(": ");
+        appendStr(err.message);
+    }
+    return buf[0 .. pos];
+}
+
+// Append the Error to ~/.local/share/ground/errors/<sessionId>.log as a
+// simple one-line record. Best-effort — returns true if the write
+// completed, false if any step failed (mkdir/open/write). No exception
+// on failure (would itself be a swallow).
+private bool writeBreadcrumb(const ref GroundError err) {
+    import core.stdc.stdlib : getenv;
+    auto home = getenv("HOME\0".ptr);
+    if (home is null) return false;
+
+    size_t hlen = 0;
+    while (home[hlen] != 0) hlen++;
+
+    // Build directory: <home>/.local/share/ground/errors
+    char[512] dirBuf = 0;
+    size_t p = 0;
+    foreach (i; 0 .. hlen) { if (p < dirBuf.length - 1) dirBuf[p++] = home[i]; }
+    foreach (c; "/.local/share/ground/errors") { if (p < dirBuf.length - 1) dirBuf[p++] = c; }
+    dirBuf[p] = 0;
+
+    // mkdir (idempotent-ish; may fail because it already exists — fine).
+    mkdir(&dirBuf[0], octal!755);
+
+    // Build file path: <dir>/<sessionId>.log
+    char[768] pathBuf = 0;
+    size_t q = 0;
+    foreach (i; 0 .. p) { if (q < pathBuf.length - 1) pathBuf[q++] = dirBuf[i]; }
+    if (q < pathBuf.length - 1) pathBuf[q++] = '/';
+    foreach (c; err.sessionId) { if (q < pathBuf.length - 1) pathBuf[q++] = c; }
+    foreach (c; ".log") { if (q < pathBuf.length - 1) pathBuf[q++] = c; }
+    pathBuf[q] = 0;
+
+    int fd = open(&pathBuf[0], O_WRONLY | O_CREAT | O_APPEND, octal!644);
+    if (fd < 0) return false;
+
+    // Format one line: "<ts>\t<origin>\t<control>\t<exit>\terrno=<n>\t<message>\n"
+    char[2048] line = 0;
+    size_t lp = 0;
+    void append(const(char)[] s) {
+        foreach (c; s) { if (lp < line.length - 1) line[lp++] = c; }
+    }
+    void appendInt(long v) {
+        if (v == 0) { append("0"); return; }
+        bool neg = v < 0;
+        if (neg) v = -v;
+        char[24] nb = 0;
+        int nl = 0;
+        while (v > 0 && nl < 23) { nb[nl++] = cast(char)('0' + v % 10); v /= 10; }
+        if (neg) { append("-"); }
+        foreach_reverse (i; 0 .. nl) { if (lp < line.length - 1) line[lp++] = nb[i]; }
+    }
+
+    appendInt(err.timestamp); append("\t");
+    append(err.origin); append("\t");
+    append(err.controlName); append("\t");
+    append("exit="); appendInt(err.exitCode); append("\t");
+    append("errno="); appendInt(err.errnoVal); append("\t");
+    append(err.message); append("\n");
+    // Preserve BOTH streams in the breadcrumb — the fallback must carry
+    // the same information as the primary would have. Labeled, indented
+    // for readability. Empty streams are simply omitted.
+    if (err.stdout.length > 0) {
+        append("  stdout:\n");
+        // indent each line
+        bool startOfLine = true;
+        foreach (c; err.stdout) {
+            if (startOfLine) { append("    "); startOfLine = false; }
+            if (lp < line.length - 1) line[lp++] = c;
+            if (c == '\n') startOfLine = true;
+        }
+        if (!startOfLine) append("\n");
+    }
+    if (err.stderr.length > 0) {
+        append("  stderr:\n");
+        bool startOfLine = true;
+        foreach (c; err.stderr) {
+            if (startOfLine) { append("    "); startOfLine = false; }
+            if (lp < line.length - 1) line[lp++] = c;
+            if (c == '\n') startOfLine = true;
+        }
+        if (!startOfLine) append("\n");
+    }
+
+    auto n = write(fd, &line[0], lp);
+    close(fd);
+    return n == cast(long) lp;
+}
+
+// Fallback 2: write to stderr. Grandchild inherits fd 2 from wrapper
+// which inherits from ground which inherits from Claude Code's Bash
+// dispatch. If any of those chains still has a live consumer, the
+// message reaches somewhere.
+private bool writeStderr(const ref GroundError err) {
+    char[1024] line = 0;
+    size_t lp = 0;
+    void append(const(char)[] s) {
+        foreach (c; s) { if (lp < line.length - 1) line[lp++] = c; }
+    }
+    append("ground error: ");
+    append(err.origin);
+    append(": ");
+    append(err.message);
+    append("\n");
+    auto n = write(STDERR_FD, &line[0], lp);
+    return n == cast(long) lp;
+}
+
+// octal! helper mirrored from exec.d — small and self-contained.
+private template octal(uint n) {
+    static if (n < 10)
+        enum uint octal = n;
+    else
+        enum uint octal = octal!(n / 10) * 8 + (n % 10);
+}

--- a/source/errors.d
+++ b/source/errors.d
@@ -27,15 +27,32 @@ struct GroundError {
 
 extern (C) {
     int open(const(char)* path, int flags, uint mode);
+    long read(int fd, void* buf, size_t count);
     long write(int fd, const(void)* buf, size_t count);
     int close(int fd);
     int mkdir(const(char)* path, uint mode);
+    int unlink(const(char)* path);
+    void* fopen(const(char)* path, const(char)* mode);
+    int fclose(void* f);
+    size_t fread(void* ptr, size_t size, size_t nmemb, void* stream);
+    void* popen(const(char)* command, const(char)* mode);
+    int pclose(void* stream);
+    char* getenv(const(char)* name);
 }
 
 enum O_WRONLY = 1;
+enum O_RDONLY = 0;
 enum O_CREAT  = 0x0200; // macOS
+enum O_TRUNC  = 0x0400; // macOS
 enum O_APPEND = 8;
 enum STDERR_FD = 2;
+
+// Grace period added to a control's timeoutSec before scanVanishedWrappers
+// treats a marker as stale. The wrapper's timeout path SIGTERM→wait2s→SIGKILL
+// →waitpid→clearMarker→emitError. Worst case is timeoutSec + ~2s to reach
+// the clear. 5s covers that comfortably without making user wait long
+// after a genuinely-vanished wrapper.
+enum GRACE_SEC = 5;
 
 // Deliver an Error through progressively cheaper channels. Returns the
 // name of the channel that succeeded, or empty if ALL channels failed
@@ -228,6 +245,246 @@ private bool writeStderr(const ref GroundError err) {
     return n == cast(long) lp;
 }
 
+// --- Exec inflight markers ---
+//
+// Under the ERROR AXIOM: dispatchExec's parent forks a wrapper and returns
+// immediately so it doesn't block the hook. Every wrapper end-path calls
+// deliverError, so a clean wrapper always announces itself. The hole: if
+// the wrapper dies BEFORE reaching its terminal emitError — SIGKILL, OOM,
+// segfault, kernel panic recovery, anything — nothing lands and the axiom
+// is silently violated.
+//
+// The marker closes the hole:
+//   - parent writes a marker at ~/.local/share/ground/exec-inflight/<sid>__<pid>.mark
+//     containing startTs, timeoutSec, controlName, toolUseId, cwd
+//   - wrapper unlinks its own marker before every terminal emitError
+//   - every hook cycle calls scanVanishedWrappers(sessionId), which finds
+//     markers older than startTs + timeoutSec + GRACE_SEC, emits a
+//     GroundError with origin="exec.wrapper.vanished", and unlinks
+//
+// Two ways a marker can be stale:
+//   (a) wrapper died silently — the case this exists for
+//   (b) the scanning hook fired before the wrapper cleared — impossible
+//       within timeoutSec+GRACE_SEC, since the wrapper's timeout branch
+//       clears+emits after SIGTERM+SIGKILL sequence which takes ≤2s
+
+private const(char)[] getHomeStr() {
+    auto h = getenv("HOME\0".ptr);
+    if (h is null) return null;
+    size_t n = 0;
+    while (h[n] != 0) n++;
+    return h[0 .. n];
+}
+
+// Fill buf with "<home>/.local/share/ground/exec-inflight" and return length
+// (excluding the trailing NUL that is also written). Zero on failure.
+package size_t buildInflightDir(ref char[512] buf) {
+    auto home = getHomeStr();
+    if (home is null) return 0;
+    size_t p = 0;
+    foreach (c; home) { if (p < buf.length - 1) buf[p++] = c; }
+    foreach (c; "/.local/share/ground/exec-inflight") { if (p < buf.length - 1) buf[p++] = c; }
+    buf[p] = 0;
+    return p;
+}
+
+// Fill buf with "<inflight-dir>/<sid>__<pid>.mark". Zero on failure.
+package size_t buildInflightPath(ref char[512] buf, const(char)[] sessionId, int pid) {
+    auto p = buildInflightDir(buf);
+    if (p == 0) return 0;
+    if (p >= buf.length - 1) return 0;
+    buf[p++] = '/';
+    foreach (c; sessionId) { if (p < buf.length - 1) buf[p++] = c; }
+    if (p >= buf.length - 3) return 0;
+    buf[p++] = '_'; buf[p++] = '_';
+    // pid as decimal
+    if (pid < 0) return 0;
+    char[16] db = 0;
+    int dl = 0;
+    if (pid == 0) { db[0] = '0'; dl = 1; }
+    else { int v = pid; while (v > 0 && dl < 15) { db[dl++] = cast(char)('0' + v % 10); v /= 10; } }
+    foreach_reverse (i; 0 .. dl) { if (p < buf.length - 1) buf[p++] = db[i]; }
+    foreach (c; ".mark") { if (p < buf.length - 1) buf[p++] = c; }
+    buf[p] = 0;
+    return p;
+}
+
+// Parent-side: called by dispatchExec after fork() returns wrapperPid > 0.
+// Best-effort — a failure to write the marker is itself an Error, but
+// emitting one here (before returning to the hook) would violate the
+// "return immediately" contract. Instead, if we can't write the marker
+// we degrade to "wrapper is on its own"; the wrapper's own terminal
+// emit still lands. The marker exists ONLY to catch wrapper-vanished.
+void writeInflightMarker(
+    string sessionId, string controlName, string toolUseId,
+    int wrapperPid, long startTs, int timeoutSec, const(char)[] cwd,
+) {
+    if (sessionId.length == 0 || wrapperPid <= 0) return;
+
+    char[512] dirBuf = 0;
+    if (buildInflightDir(dirBuf) == 0) return;
+    mkdir(&dirBuf[0], octal!755);
+
+    char[512] pathBuf = 0;
+    if (buildInflightPath(pathBuf, sessionId, wrapperPid) == 0) return;
+
+    int fd = open(&pathBuf[0], O_WRONLY | O_CREAT | O_TRUNC, octal!644);
+    if (fd < 0) return;
+
+    char[4096] cbuf = 0;
+    size_t cp = 0;
+    void put(const(char)[] s) { foreach (c; s) if (cp < cbuf.length - 1) cbuf[cp++] = c; }
+    void putI(long v) {
+        if (v == 0) { put("0"); return; }
+        bool neg = v < 0;
+        if (neg) v = -v;
+        char[24] nb = 0;
+        int nl = 0;
+        while (v > 0 && nl < 23) { nb[nl++] = cast(char)('0' + v % 10); v /= 10; }
+        if (neg) put("-");
+        foreach_reverse (i; 0 .. nl) { if (cp < cbuf.length - 1) cbuf[cp++] = nb[i]; }
+    }
+    putI(startTs);    put("\n");
+    putI(timeoutSec); put("\n");
+    put(controlName); put("\n");
+    put(toolUseId);   put("\n");
+    put(cwd);         put("\n");
+    cast(void) write(fd, &cbuf[0], cp);
+    close(fd);
+}
+
+// Wrapper-side: called before every terminal emitError (normal exit,
+// non-zero exit, timeout, pre-execv failure inside wrapper). Unlinks
+// its own marker so the next scan doesn't false-positive.
+void clearInflightMarker(string sessionId, int wrapperPid) {
+    if (sessionId.length == 0 || wrapperPid <= 0) return;
+    char[512] pathBuf = 0;
+    if (buildInflightPath(pathBuf, sessionId, wrapperPid) == 0) return;
+    unlink(&pathBuf[0]);
+}
+
+// Every-hook: scan this session's inflight markers. For any older than
+// startTs + timeoutSec + GRACE_SEC, emit a GroundError via deliverError
+// (origin "exec.wrapper.vanished") and unlink so we don't re-emit on
+// subsequent hooks. Best-effort — failure to enumerate is itself silent
+// (there's no meaningful Error to raise about a missing HOME).
+void scanVanishedWrappers(string sessionId) {
+    import core.stdc.time : time;
+
+    if (sessionId.length == 0) return;
+
+    auto home = getHomeStr();
+    if (home is null) return;
+
+    // Enumerate via popen(ls) — same pattern as watch.d. readdir on macOS
+    // links against the 32-bit-inode struct which D's core.stdc.dirent
+    // doesn't match, so shell-out is the portable path.
+    char[1024] cmd = 0;
+    size_t cp = 0;
+    void put(const(char)[] s) { foreach (c; s) if (cp < cmd.length - 1) cmd[cp++] = c; }
+    put("ls ");
+    put(home);
+    put("/.local/share/ground/exec-inflight/");
+    put(sessionId);
+    put("__*.mark 2>/dev/null");
+    cmd[cp] = 0;
+
+    auto pipe = popen(&cmd[0], "r\0".ptr);
+    if (pipe is null) return;
+
+    auto now = cast(long) time(null);
+
+    char[512] line = 0;
+    while (true) {
+        size_t ll = 0;
+        while (ll < line.length - 1) {
+            char[1] ch;
+            if (fread(&ch[0], 1, 1, pipe) != 1) break;
+            if (ch[0] == '\n') break;
+            line[ll++] = ch[0];
+        }
+        if (ll == 0) break;
+        line[ll] = 0;
+
+        // Read the marker file's own content for its metadata.
+        int fd = open(&line[0], O_RDONLY, 0);
+        if (fd < 0) continue;
+        char[4096] cbuf = 0;
+        auto n = read(fd, &cbuf[0], cbuf.length - 1);
+        close(fd);
+        if (n <= 0) continue;
+        auto body_ = cast(const(char)[]) cbuf[0 .. cast(size_t) n];
+
+        // Parse: startTs\ntimeoutSec\ncontrolName\ntoolUseId\ncwd
+        long startTs = 0;
+        int timeoutSec = 0;
+        const(char)[] controlName;
+        const(char)[] toolUseId;
+        {
+            size_t i = 0;
+            // startTs
+            while (i < body_.length && body_[i] >= '0' && body_[i] <= '9') {
+                startTs = startTs * 10 + (body_[i] - '0'); i++;
+            }
+            if (i < body_.length && body_[i] == '\n') i++;
+            // timeoutSec
+            while (i < body_.length && body_[i] >= '0' && body_[i] <= '9') {
+                timeoutSec = timeoutSec * 10 + (body_[i] - '0'); i++;
+            }
+            if (i < body_.length && body_[i] == '\n') i++;
+            // controlName up to next \n
+            auto cs = i;
+            while (i < body_.length && body_[i] != '\n') i++;
+            controlName = body_[cs .. i];
+            if (i < body_.length) i++;
+            // toolUseId up to next \n
+            auto ts = i;
+            while (i < body_.length && body_[i] != '\n') i++;
+            toolUseId = body_[ts .. i];
+        }
+
+        auto ageDeadline = startTs + cast(long) timeoutSec + GRACE_SEC;
+        if (now < ageDeadline) continue;
+
+        // Extract wrapperPid from the filename tail: <sid>__<pid>.mark
+        int wrapperPid = 0;
+        {
+            // scan from end backwards past ".mark"
+            size_t e = ll;
+            if (e > 5) e -= 5; // skip ".mark"
+            size_t s = e;
+            while (s > 0 && line[s - 1] >= '0' && line[s - 1] <= '9') s--;
+            foreach (i; s .. e) wrapperPid = wrapperPid * 10 + (line[i] - '0');
+        }
+
+        // Copy fields so the strings survive after we unlink the file /
+        // reuse cbuf. cbuf is stack; copy into __gshared bufs.
+        __gshared char[256] cnBuf = 0;
+        __gshared char[128] tuBuf = 0;
+        size_t cnl = controlName.length < cnBuf.length ? controlName.length : cnBuf.length - 1;
+        foreach (i; 0 .. cnl) cnBuf[i] = controlName[i];
+        size_t tul = toolUseId.length < tuBuf.length ? toolUseId.length : tuBuf.length - 1;
+        foreach (i; 0 .. tul) tuBuf[i] = toolUseId[i];
+
+        GroundError err;
+        err.origin      = "exec.wrapper.vanished";
+        err.message     = "wrapper process died before delivering result";
+        err.errnoVal    = 0;
+        err.exitCode    = -1;
+        err.sessionId   = sessionId;
+        err.controlName = cast(string) cnBuf[0 .. cnl];
+        err.toolUseId   = cast(string) tuBuf[0 .. tul];
+        err.timestamp   = now;
+        err.stdout      = "";
+        err.stderr      = "";
+        cast(void) deliverError(err);
+
+        unlink(&line[0]);
+    }
+
+    pclose(pipe);
+}
+
 // octal! helper mirrored from exec.d — small and self-contained.
 private template octal(uint n) {
     static if (n < 10)
@@ -235,3 +492,4 @@ private template octal(uint n) {
     else
         enum uint octal = octal!(n / 10) * 8 + (n % 10);
 }
+

--- a/source/errors.d
+++ b/source/errors.d
@@ -485,6 +485,91 @@ void scanVanishedWrappers(string sessionId) {
     pclose(pipe);
 }
 
+// --- Watch health / delivery-pipeline check ---
+//
+// Under the ERROR AXIOM: if the watch daemon dies mid-cycle or fails to
+// spawn, rows written by dispatchExec's wrapper sit in the db forever and
+// no one sees them. That's a silent violation.
+//
+// The check combines two signals to avoid false positives:
+//   - isWatchAlive: pid file exists and its pid is still running
+//   - countPendingImmediateForSession: undelivered immediate:* rows for
+//     this session
+//
+// Watch dead + no pending: normal state between Stops (watch exits 2 after
+// delivering). Pending + watch alive: normal wait for next 2s poll. Only
+// BOTH together indicate a broken pipeline.
+//
+// Callers: at Stop, use immediateBacklogMessage to prepend the warning to
+// the Stop response so it surfaces at point of interaction. At PostToolUse,
+// use writeImmediateBacklogStderr as best-effort visibility (stderr from
+// PostToolUse shows in Claude Code's transcript-mode view).
+
+// Returns the number of pending immediate:* messages for this session
+// when the watch daemon is dead, or 0 otherwise (either watch alive OR
+// nothing pending).
+long detectImmediateBacklog(string sessionId) {
+    import db : openDb, sqlite3_close;
+    import immediate : countPendingImmediateForSession;
+    import watch : isWatchAlive;
+
+    if (sessionId.length == 0) return 0;
+    if (isWatchAlive(sessionId)) return 0;
+
+    auto db = openDb();
+    if (db is null) return 0;
+    auto n = countPendingImmediateForSession(db, sessionId);
+    sqlite3_close(db);
+    return n > 0 ? n : 0;
+}
+
+// Format the backlog warning into a fixed __gshared buffer. Slice is stable
+// until the next call. Empty result means "no backlog, nothing to report."
+const(char)[] immediateBacklogMessage(string sessionId) {
+    auto n = detectImmediateBacklog(sessionId);
+    if (n <= 0) return null;
+
+    __gshared char[256] buf = 0;
+    size_t pos = 0;
+    void put(const(char)[] s) { foreach (c; s) if (pos < buf.length - 1) buf[pos++] = c; }
+    void putI(long v) {
+        if (v == 0) { put("0"); return; }
+        char[24] nb = 0; int nl = 0;
+        while (v > 0 && nl < 23) { nb[nl++] = cast(char)('0' + v % 10); v /= 10; }
+        foreach_reverse (i; 0 .. nl) if (pos < buf.length - 1) buf[pos++] = nb[i];
+    }
+    put("ground error: ");
+    putI(n);
+    put(" undelivered exec message(s) — watch daemon is not running for this session");
+    return buf[0 .. pos];
+}
+
+// Best-effort stderr emission for PostToolUse — shows in Claude Code's
+// transcript-mode view. Also writes a breadcrumb line so the record is
+// durable even if stderr goes unseen.
+void writeImmediateBacklogStderr(string sessionId) {
+    auto msg = immediateBacklogMessage(sessionId);
+    if (msg.length == 0) return;
+
+    // stderr
+    char[300] line = 0;
+    size_t lp = 0;
+    foreach (c; msg) { if (lp < line.length - 1) line[lp++] = c; }
+    if (lp < line.length - 1) line[lp++] = '\n';
+    cast(void) write(STDERR_FD, &line[0], lp);
+
+    // breadcrumb — reuse the errors/<sid>.log so history persists
+    GroundError err;
+    err.origin      = "watch.dead";
+    err.message     = cast(string) msg;
+    err.sessionId   = sessionId;
+    err.controlName = "";
+    err.toolUseId   = "";
+    import core.stdc.time : time;
+    err.timestamp   = cast(long) time(null);
+    cast(void) writeBreadcrumb(err);
+}
+
 // octal! helper mirrored from exec.d — small and self-contained.
 private template octal(uint n) {
     static if (n < 10)

--- a/source/exec.d
+++ b/source/exec.d
@@ -1,11 +1,30 @@
 module exec;
 
+extern (C) {
+    int fork();
+    int execv(const(char)* path, const(char*)* argv);
+    int setenv(const(char)* name, const(char)* value, int overwrite);
+    void _exit(int status);
+    int mkstemp(char* templ);
+    long write(int fd, const(void)* buf, size_t count);
+    int close(int fd);
+    int chmod(const(char)* path, uint mode);
+}
+
 // Merged env for the exec child. 24 = 8 (control) + 16 (project) — the
 // max possible if both are full with disjoint keys. Runtime never sees
 // more than this.
 struct MergedEnv {
     string[24] keys;
     string[24] values;
+    ubyte count;
+}
+
+// Full env dict for the child process. GROUND_ floor (3 slots) + merged
+// env (24 max) = 27 max entries. Sized to 32 for slack.
+struct ChildEnv {
+    string[32] keys;
+    string[32] values;
     ubyte count;
 }
 
@@ -48,4 +67,127 @@ MergedEnv mergeEnv(
     }
 
     return result;
+}
+
+// Build the full env dict passed to an exec child. GROUND_ vars come first
+// (positions 0..2, always present), then merged (project + control) pairs.
+// Pbt authors should not declare GROUND_-prefixed keys in env {} blocks —
+// GROUND_ names are reserved for the runtime floor. Nothing enforces this
+// today; it's a convention.
+ChildEnv prepareChildEnv(
+    const(string)[] controlKeys, const(string)[] controlValues,
+    const(string)[] projectKeys, const(string)[] projectValues,
+    string sessionId, string cwd, string toolInput,
+) {
+    ChildEnv result;
+
+    result.keys[0]   = "GROUND_SESSION_ID";
+    result.values[0] = sessionId;
+    result.keys[1]   = "GROUND_CWD";
+    result.values[1] = cwd;
+    result.keys[2]   = "GROUND_TOOL_INPUT";
+    result.values[2] = toolInput;
+    result.count = 3;
+
+    auto merged = mergeEnv(controlKeys, controlValues, projectKeys, projectValues);
+    foreach (i; 0 .. merged.count) {
+        result.keys[result.count]   = merged.keys[i];
+        result.values[result.count] = merged.values[i];
+        result.count++;
+    }
+
+    return result;
+}
+
+// Fire the exec target as a detached child. Parent returns immediately
+// regardless of outcome — no waiting, no zombies (child is inherited by
+// init when ground's hook process exits shortly after).
+//
+// exec: values are inline script content (not paths). Ground writes the
+// content to a mktemp'd file at fire time, chmods +x, and execv's the
+// file. /tmp housekeeping cleans up the file eventually. The pbt is the
+// single source of truth for what runs — no separate .fish file to keep
+// in sync with the control declaration.
+//
+// Project env for cwd is resolved from controls.allParsed via
+// longest-path-wins match, matching envSubst's own resolution rule.
+void dispatchExec(
+    string execScript,
+    const(string)[] controlKeys, const(string)[] controlValues,
+    string sessionId, const(char)[] cwd, const(char)[] toolInput,
+) {
+    import controls : allParsed;
+    import matcher : contains;
+
+    if (execScript.length == 0) return;
+
+    static immutable parsed = allParsed;
+    int bestIdx = -1;
+    size_t bestLen = 0;
+    foreach (i; 0 .. parsed.envCount) {
+        if (parsed.envs[i].path.length > 0 && contains(cwd, parsed.envs[i].path)) {
+            if (parsed.envs[i].path.length > bestLen) {
+                bestLen = parsed.envs[i].path.length;
+                bestIdx = cast(int) i;
+            }
+        }
+    }
+
+    const(string)[] projectKeys;
+    const(string)[] projectValues;
+    if (bestIdx >= 0) {
+        projectKeys   = parsed.envs[bestIdx].keys[0 .. parsed.envs[bestIdx].count];
+        projectValues = parsed.envs[bestIdx].values[0 .. parsed.envs[bestIdx].count];
+    }
+
+    auto env = prepareChildEnv(
+        controlKeys, controlValues,
+        projectKeys, projectValues,
+        cast(string) sessionId, cast(string) cwd, cast(string) toolInput,
+    );
+
+    // Materialize the inline script to a private tempfile.
+    // mkstemp creates the file with mode 0600 (owner rw only).
+    char[64] tmpPath = 0;
+    string templ = "/tmp/ground-exec-XXXXXX";
+    foreach (i, ch; templ) tmpPath[i] = ch;
+    int fd = mkstemp(&tmpPath[0]);
+    if (fd < 0) return;
+
+    if (write(fd, execScript.ptr, execScript.length) != cast(long) execScript.length) {
+        close(fd);
+        return;
+    }
+    close(fd);
+
+    // 0o700 = owner rwx, no group/other. Keeps the script private and
+    // executable — no world-writable exposure.
+    if (chmod(&tmpPath[0], octal!700) != 0) return;
+
+    auto pid = fork();
+    if (pid != 0) return;
+
+    // Child.
+    foreach (i; 0 .. env.count) {
+        char[256]  kbuf = 0;
+        char[8192] vbuf = 0;
+        auto k = env.keys[i];
+        auto v = env.values[i];
+        if (k.length >= kbuf.length || v.length >= vbuf.length) continue;
+        foreach (j, ch; k) kbuf[j] = ch;
+        foreach (j, ch; v) vbuf[j] = ch;
+        setenv(&kbuf[0], &vbuf[0], 1);
+    }
+
+    const(char)*[2] argv = [cast(const(char)*) &tmpPath[0], null];
+    execv(&tmpPath[0], argv.ptr);
+    _exit(127); // execv only returns on error
+}
+
+// Helper for octal literals (D's 0o syntax is deprecated).
+private template octal(uint n) {
+    static if (n < 10)
+        enum uint octal = n;
+    else
+        enum uint octal = octal!(n / 10) * 8 + (n % 10);
 }

--- a/source/exec.d
+++ b/source/exec.d
@@ -1,5 +1,7 @@
 module exec;
 
+import core.stdc.errno : errno;
+
 extern (C) {
     int fork();
     int execv(const(char)* path, const(char*)* argv);
@@ -13,7 +15,6 @@ extern (C) {
     int pipe(int* pipefd);
     int dup2(int oldfd, int newfd);
     int waitpid(int pid, int* wstatus, int options);
-    int* __error(); // macOS thread-local errno
     int kill(int pid, int sig);
     int getpid();
 
@@ -35,8 +36,6 @@ enum WNOHANG = 1;
 // Default script timeout in seconds when handler_params doesn't specify.
 // Long enough for realistic deploy scripts; short enough to catch hangs.
 enum DEFAULT_TIMEOUT_SEC = 300;
-
-private int errno() { return *__error(); }
 
 // Under the ERROR AXIOM: every failure path constructs a GroundError and
 // calls deliverError. This helper packages the boilerplate. When called,

--- a/source/exec.d
+++ b/source/exec.d
@@ -7,8 +7,12 @@ extern (C) {
     void _exit(int status);
     int mkstemp(char* templ);
     long write(int fd, const(void)* buf, size_t count);
+    long read(int fd, void* buf, size_t count);
     int close(int fd);
     int chmod(const(char)* path, uint mode);
+    int pipe(int* pipefd);
+    int dup2(int oldfd, int newfd);
+    int waitpid(int pid, int* wstatus, int options);
 }
 
 // Merged env for the exec child. 24 = 8 (control) + 16 (project) — the
@@ -113,6 +117,7 @@ ChildEnv prepareChildEnv(
 // longest-path-wins match, matching envSubst's own resolution rule.
 void dispatchExec(
     string execScript,
+    string controlName,
     const(string)[] controlKeys, const(string)[] controlValues,
     string sessionId, const(char)[] cwd, const(char)[] toolInput,
 ) {
@@ -164,24 +169,70 @@ void dispatchExec(
     // executable — no world-writable exposure.
     if (chmod(&tmpPath[0], octal!700) != 0) return;
 
-    auto pid = fork();
-    if (pid != 0) return;
+    // One pipe for stdout capture. Parent forks a wrapper (returns
+    // immediately). Wrapper forks the grandchild that becomes the script,
+    // reads the pipe, waits, writes the completion attestation.
+    int[2] outPipe;
+    if (pipe(&outPipe[0]) != 0) return;
 
-    // Child.
-    foreach (i; 0 .. env.count) {
-        char[256]  kbuf = 0;
-        char[8192] vbuf = 0;
-        auto k = env.keys[i];
-        auto v = env.values[i];
-        if (k.length >= kbuf.length || v.length >= vbuf.length) continue;
-        foreach (j, ch; k) kbuf[j] = ch;
-        foreach (j, ch; v) vbuf[j] = ch;
-        setenv(&kbuf[0], &vbuf[0], 1);
+    auto wrapperPid = fork();
+    if (wrapperPid != 0) {
+        close(outPipe[0]);
+        close(outPipe[1]);
+        return;
     }
 
-    const(char)*[2] argv = [cast(const(char)*) &tmpPath[0], null];
-    execv(&tmpPath[0], argv.ptr);
-    _exit(127); // execv only returns on error
+    auto scriptPid = fork();
+    if (scriptPid == 0) {
+        // Grandchild.
+        dup2(outPipe[1], 1);
+        close(outPipe[0]);
+        close(outPipe[1]);
+
+        foreach (i; 0 .. env.count) {
+            char[256]  kbuf = 0;
+            char[8192] vbuf = 0;
+            auto k = env.keys[i];
+            auto v = env.values[i];
+            if (k.length >= kbuf.length || v.length >= vbuf.length) continue;
+            foreach (j, ch; k) kbuf[j] = ch;
+            foreach (j, ch; v) vbuf[j] = ch;
+            setenv(&kbuf[0], &vbuf[0], 1);
+        }
+
+        const(char)*[2] argv = [cast(const(char)*) &tmpPath[0], null];
+        execv(&tmpPath[0], argv.ptr);
+        _exit(127);
+    }
+
+    // Wrapper.
+    close(outPipe[1]);
+
+    char[4096] captureBuf = 0;
+    size_t captureLen = 0;
+    while (captureLen < captureBuf.length) {
+        auto n = read(outPipe[0], &captureBuf[captureLen], captureBuf.length - captureLen);
+        if (n <= 0) break;
+        captureLen += cast(size_t) n;
+    }
+    close(outPipe[0]);
+
+    int status;
+    waitpid(scriptPid, &status, 0);
+    int exitCode = (status >> 8) & 0xFF;
+
+    {
+        import immediate : writeExecComplete;
+        import db : openDb, sqlite3_close;
+        auto db = openDb();
+        if (db !is null) {
+            writeExecComplete(db, sessionId, controlName, exitCode,
+                              captureBuf[0 .. captureLen]);
+            sqlite3_close(db);
+        }
+    }
+
+    _exit(0);
 }
 
 // Helper for octal literals (D's 0o syntax is deprecated).

--- a/source/exec.d
+++ b/source/exec.d
@@ -1,0 +1,51 @@
+module exec;
+
+// Merged env for the exec child. 24 = 8 (control) + 16 (project) — the
+// max possible if both are full with disjoint keys. Runtime never sees
+// more than this.
+struct MergedEnv {
+    string[24] keys;
+    string[24] values;
+    ubyte count;
+}
+
+// Layer control-env on top of project-env. Control wins on collision;
+// non-colliding pairs union together. Position is stable: project pairs
+// first (in arrival order), then non-collision control pairs. Colliding
+// control values overwrite in place — the key does not move.
+//
+// GROUND_-prefixed vars (session_id, cwd, tool_input) are prepended at
+// runtime dispatch time, not by this function. This function stays pure
+// so the precedence rule can be locked in via CTFE tests.
+MergedEnv mergeEnv(
+    const(string)[] controlKeys, const(string)[] controlValues,
+    const(string)[] projectKeys, const(string)[] projectValues,
+) {
+    MergedEnv result;
+
+    foreach (i; 0 .. projectKeys.length) {
+        if (projectKeys[i] is null || projectKeys[i].length == 0) continue;
+        result.keys[result.count] = projectKeys[i];
+        result.values[result.count] = projectValues[i];
+        result.count++;
+    }
+
+    foreach (i; 0 .. controlKeys.length) {
+        if (controlKeys[i] is null || controlKeys[i].length == 0) continue;
+        bool overwritten = false;
+        foreach (j; 0 .. result.count) {
+            if (result.keys[j] == controlKeys[i]) {
+                result.values[j] = controlValues[i];
+                overwritten = true;
+                break;
+            }
+        }
+        if (!overwritten) {
+            result.keys[result.count] = controlKeys[i];
+            result.values[result.count] = controlValues[i];
+            result.count++;
+        }
+    }
+
+    return result;
+}

--- a/source/exec.d
+++ b/source/exec.d
@@ -13,6 +13,55 @@ extern (C) {
     int pipe(int* pipefd);
     int dup2(int oldfd, int newfd);
     int waitpid(int pid, int* wstatus, int options);
+    int* __error(); // macOS thread-local errno
+    int kill(int pid, int sig);
+    int getpid();
+
+    struct pollfd {
+        int fd;
+        short events;
+        short revents;
+    }
+    int poll(pollfd* fds, uint nfds, int timeout);
+}
+
+enum POLLIN  = 0x001;
+enum POLLHUP = 0x010;
+enum POLLERR = 0x008;
+enum SIGTERM = 15;
+enum SIGKILL = 9;
+enum WNOHANG = 1;
+
+// Default script timeout in seconds when handler_params doesn't specify.
+// Long enough for realistic deploy scripts; short enough to catch hangs.
+enum DEFAULT_TIMEOUT_SEC = 300;
+
+private int errno() { return *__error(); }
+
+// Under the ERROR AXIOM: every failure path constructs a GroundError and
+// calls deliverError. This helper packages the boilerplate. When called,
+// SOMETHING lands in front of the user — via db, breadcrumb, or stderr.
+// Never a silent return.
+private void emitError(
+    string origin, string message,
+    int errnoVal, int exitCode,
+    string sessionId, string controlName, string toolUseId,
+    string stdoutData, string stderrData,
+) {
+    import errors : GroundError, deliverError;
+    import core.stdc.time : time;
+    GroundError err;
+    err.origin      = origin;
+    err.message     = message;
+    err.errnoVal    = errnoVal;
+    err.exitCode    = exitCode;
+    err.sessionId   = sessionId;
+    err.controlName = controlName;
+    err.toolUseId   = toolUseId;
+    err.timestamp   = cast(long) time(null);
+    err.stdout      = stdoutData;
+    err.stderr      = stderrData;
+    cast(void) deliverError(err);
 }
 
 // Merged env for the exec child. 24 = 8 (control) + 16 (project) — the
@@ -103,28 +152,39 @@ ChildEnv prepareChildEnv(
     return result;
 }
 
-// Fire the exec target as a detached child. Parent returns immediately
-// regardless of outcome — no waiting, no zombies (child is inherited by
-// init when ground's hook process exits shortly after).
+// Fire the exec target as a detached child. Parent forks a wrapper and
+// returns; the wrapper spawns the script grandchild, captures stdout AND
+// stderr, enforces a timeout, and emits exactly one terminal Error via
+// deliverError. Every failure path — pre-execv or otherwise — constructs
+// a GroundError. No silent returns. Per the ERROR AXIOM.
 //
 // exec: values are inline script content (not paths). Ground writes the
-// content to a mktemp'd file at fire time, chmods +x, and execv's the
-// file. /tmp housekeeping cleans up the file eventually. The pbt is the
-// single source of truth for what runs — no separate .fish file to keep
-// in sync with the control declaration.
+// content to a mkstemp'd file at fire time, chmods +x, and execv's the
+// file. /tmp housekeeping cleans up the file eventually.
 //
 // Project env for cwd is resolved from controls.allParsed via
 // longest-path-wins match, matching envSubst's own resolution rule.
+//
+// timeoutSec: how many seconds the wrapper waits before SIGTERM'ing the
+// grandchild. 0 or negative → use DEFAULT_TIMEOUT_SEC.
 void dispatchExec(
     string execScript,
     string controlName,
+    string toolUseId,
+    int timeoutSec,
     const(string)[] controlKeys, const(string)[] controlValues,
     string sessionId, const(char)[] cwd, const(char)[] toolInput,
 ) {
     import controls : allParsed;
     import matcher : contains;
 
-    if (execScript.length == 0) return;
+    if (execScript.length == 0) {
+        emitError("exec.dispatch", "control has empty exec: script",
+                  0, -1, sessionId, controlName, toolUseId, "", "");
+        return;
+    }
+
+    if (timeoutSec <= 0) timeoutSec = DEFAULT_TIMEOUT_SEC;
 
     static immutable parsed = allParsed;
     int bestIdx = -1;
@@ -151,43 +211,84 @@ void dispatchExec(
         cast(string) sessionId, cast(string) cwd, cast(string) toolInput,
     );
 
-    // Materialize the inline script to a private tempfile.
-    // mkstemp creates the file with mode 0600 (owner rw only).
+    // --- Materialize script to a private tempfile ---
+
     char[64] tmpPath = 0;
     string templ = "/tmp/ground-exec-XXXXXX";
     foreach (i, ch; templ) tmpPath[i] = ch;
     int fd = mkstemp(&tmpPath[0]);
-    if (fd < 0) return;
+    if (fd < 0) {
+        emitError("exec.mkstemp", "mkstemp failed",
+                  errno(), -1, sessionId, controlName, toolUseId, "", "");
+        return;
+    }
 
     if (write(fd, execScript.ptr, execScript.length) != cast(long) execScript.length) {
+        auto e = errno();
         close(fd);
+        emitError("exec.write", "wrote fewer bytes than script content",
+                  e, -1, sessionId, controlName, toolUseId, "", "");
         return;
     }
     close(fd);
 
-    // 0o700 = owner rwx, no group/other. Keeps the script private and
-    // executable — no world-writable exposure.
-    if (chmod(&tmpPath[0], octal!700) != 0) return;
-
-    // One pipe for stdout capture. Parent forks a wrapper (returns
-    // immediately). Wrapper forks the grandchild that becomes the script,
-    // reads the pipe, waits, writes the completion attestation.
-    int[2] outPipe;
-    if (pipe(&outPipe[0]) != 0) return;
-
-    auto wrapperPid = fork();
-    if (wrapperPid != 0) {
-        close(outPipe[0]);
-        close(outPipe[1]);
+    if (chmod(&tmpPath[0], octal!700) != 0) {
+        emitError("exec.chmod", "chmod +x failed",
+                  errno(), -1, sessionId, controlName, toolUseId, "", "");
         return;
     }
 
+    // --- Two pipes: stdout AND stderr captured independently ---
+
+    int[2] outPipe;
+    if (pipe(&outPipe[0]) != 0) {
+        emitError("exec.pipe.stdout", "pipe() failed for stdout capture",
+                  errno(), -1, sessionId, controlName, toolUseId, "", "");
+        return;
+    }
+    int[2] errPipe;
+    if (pipe(&errPipe[0]) != 0) {
+        auto e = errno();
+        close(outPipe[0]); close(outPipe[1]);
+        emitError("exec.pipe.stderr", "pipe() failed for stderr capture",
+                  e, -1, sessionId, controlName, toolUseId, "", "");
+        return;
+    }
+
+    // --- Fork wrapper. Parent returns immediately. ---
+
+    auto wrapperPid = fork();
+    if (wrapperPid < 0) {
+        auto e = errno();
+        close(outPipe[0]); close(outPipe[1]);
+        close(errPipe[0]); close(errPipe[1]);
+        emitError("exec.fork.wrapper", "fork() failed for wrapper",
+                  e, -1, sessionId, controlName, toolUseId, "", "");
+        return;
+    }
+    if (wrapperPid != 0) {
+        close(outPipe[0]); close(outPipe[1]);
+        close(errPipe[0]); close(errPipe[1]);
+        return;
+    }
+
+    // --- Wrapper (child of ground) ---
+
     auto scriptPid = fork();
+    if (scriptPid < 0) {
+        auto e = errno();
+        close(outPipe[0]); close(outPipe[1]);
+        close(errPipe[0]); close(errPipe[1]);
+        emitError("exec.fork.script", "fork() failed for script",
+                  e, -1, sessionId, controlName, toolUseId, "", "");
+        _exit(0);
+    }
     if (scriptPid == 0) {
-        // Grandchild.
+        // --- Grandchild (script) ---
         dup2(outPipe[1], 1);
-        close(outPipe[0]);
-        close(outPipe[1]);
+        dup2(errPipe[1], 2);
+        close(outPipe[0]); close(outPipe[1]);
+        close(errPipe[0]); close(errPipe[1]);
 
         foreach (i; 0 .. env.count) {
             char[256]  kbuf = 0;
@@ -202,37 +303,116 @@ void dispatchExec(
 
         const(char)*[2] argv = [cast(const(char)*) &tmpPath[0], null];
         execv(&tmpPath[0], argv.ptr);
-        _exit(127);
+        _exit(127); // execv only returns on failure
     }
 
-    // Wrapper.
+    // Wrapper: close write ends (grandchild owns them). Poll-read both
+    // pipes concurrently with per-cycle timeout. Track cumulative
+    // wall-clock; if we exceed timeoutSec, SIGTERM (then SIGKILL) the
+    // grandchild and emit a timeout Error.
     close(outPipe[1]);
+    close(errPipe[1]);
 
-    char[4096] captureBuf = 0;
-    size_t captureLen = 0;
-    while (captureLen < captureBuf.length) {
-        auto n = read(outPipe[0], &captureBuf[captureLen], captureBuf.length - captureLen);
-        if (n <= 0) break;
-        captureLen += cast(size_t) n;
+    char[4096] outBuf = 0; size_t outLen = 0;
+    char[4096] errBuf = 0; size_t errLen = 0;
+    bool outOpen = true, errOpen = true;
+
+    import core.stdc.time : time;
+    auto startTs = cast(long) time(null);
+    bool timedOut = false;
+
+    while (outOpen || errOpen) {
+        auto elapsed = cast(long) time(null) - startTs;
+        if (elapsed >= timeoutSec) {
+            timedOut = true;
+            kill(scriptPid, SIGTERM);
+            // Give it 2 seconds to react, then SIGKILL.
+            auto killDeadline = cast(long) time(null) + 2;
+            while (cast(long) time(null) < killDeadline) {
+                int st;
+                if (waitpid(scriptPid, &st, WNOHANG) != 0) break;
+            }
+            kill(scriptPid, SIGKILL);
+            break;
+        }
+
+        pollfd[2] fds;
+        uint nfds = 0;
+        if (outOpen) { fds[nfds].fd = outPipe[0]; fds[nfds].events = POLLIN; fds[nfds].revents = 0; nfds++; }
+        if (errOpen) { fds[nfds].fd = errPipe[0]; fds[nfds].events = POLLIN; fds[nfds].revents = 0; nfds++; }
+        if (nfds == 0) break;
+
+        int pollTimeoutMs = 1000; // wake once per second to re-check timeout
+        int r = poll(&fds[0], nfds, pollTimeoutMs);
+        if (r < 0) {
+            // poll error is itself an Error, but we still need to wait for
+            // grandchild. Break out and let the completion path emit.
+            break;
+        }
+        if (r == 0) continue; // timeout tick, loop back
+
+        foreach (i; 0 .. nfds) {
+            auto pf = fds[i];
+            if (pf.revents & POLLIN) {
+                char[1024] chunk;
+                auto n = read(pf.fd, &chunk[0], chunk.length);
+                if (n <= 0) {
+                    if (pf.fd == outPipe[0]) { outOpen = false; close(pf.fd); }
+                    else if (pf.fd == errPipe[0]) { errOpen = false; close(pf.fd); }
+                } else {
+                    if (pf.fd == outPipe[0])
+                        tailAppend(&outBuf[0], outLen, outBuf.length, chunk[0 .. cast(size_t) n]);
+                    else if (pf.fd == errPipe[0])
+                        tailAppend(&errBuf[0], errLen, errBuf.length, chunk[0 .. cast(size_t) n]);
+                }
+            } else if (pf.revents & (POLLHUP | POLLERR)) {
+                if (pf.fd == outPipe[0]) { outOpen = false; close(pf.fd); }
+                else if (pf.fd == errPipe[0]) { errOpen = false; close(pf.fd); }
+            }
+        }
     }
-    close(outPipe[0]);
+
+    // Drain any remaining pipe data even if we timed out (best-effort;
+    // pipes may already be closed by SIGKILL).
+    if (outOpen) close(outPipe[0]);
+    if (errOpen) close(errPipe[0]);
 
     int status;
     waitpid(scriptPid, &status, 0);
     int exitCode = (status >> 8) & 0xFF;
 
-    {
-        import immediate : writeExecComplete;
-        import db : openDb, sqlite3_close;
-        auto db = openDb();
-        if (db !is null) {
-            writeExecComplete(db, sessionId, controlName, exitCode,
-                              captureBuf[0 .. captureLen]);
-            sqlite3_close(db);
-        }
+    // Every terminal outcome — timeout, non-zero exit, normal exit —
+    // flows through the SAME error surface. The wrapper never returns
+    // silently.
+    string stdoutData = cast(string) outBuf[0 .. outLen];
+    string stderrData = cast(string) errBuf[0 .. errLen];
+    if (timedOut) {
+        emitError("exec.timeout", "grandchild exceeded configured timeout",
+                  0, exitCode, sessionId, controlName, toolUseId,
+                  stdoutData, stderrData);
+    } else {
+        emitError("exec.script", "grandchild exited",
+                  0, exitCode, sessionId, controlName, toolUseId,
+                  stdoutData, stderrData);
     }
-
     _exit(0);
+}
+
+// Bounded ring-tail buffer. If new data would overflow, drop oldest bytes
+// to keep the last capBytes. Used per stream for stdout/stderr capture.
+private void tailAppend(char* buf, ref size_t len, size_t cap, const(char)[] chunk) {
+    if (chunk.length >= cap) {
+        foreach (i; 0 .. cap) buf[i] = chunk[chunk.length - cap + i];
+        len = cap;
+        return;
+    }
+    if (len + chunk.length > cap) {
+        auto drop = len + chunk.length - cap;
+        for (size_t i = 0; i < len - drop; i++) buf[i] = buf[i + drop];
+        len -= drop;
+    }
+    foreach (i; 0 .. chunk.length) buf[len + i] = chunk[i];
+    len += chunk.length;
 }
 
 // Helper for octal literals (D's 0o syntax is deprecated).

--- a/source/exec.d
+++ b/source/exec.d
@@ -268,16 +268,30 @@ void dispatchExec(
     if (wrapperPid != 0) {
         close(outPipe[0]); close(outPipe[1]);
         close(errPipe[0]); close(errPipe[1]);
+        // Parent-side inflight marker. If the wrapper dies before its own
+        // terminal emitError clears this marker, scanVanishedWrappers picks
+        // it up on the next hook cycle and emits exec.wrapper.vanished.
+        import errors : writeInflightMarker;
+        import core.stdc.time : time;
+        writeInflightMarker(sessionId, controlName, toolUseId,
+                            wrapperPid, cast(long) time(null), timeoutSec, cwd);
         return;
     }
 
     // --- Wrapper (child of ground) ---
+
+    // In the wrapper, getpid() returns the same value as `wrapperPid` did
+    // in the parent — that's the key the parent-side marker was written
+    // with. clearInflightMarker uses it to unlink on every terminal path.
+    int myPid = getpid();
 
     auto scriptPid = fork();
     if (scriptPid < 0) {
         auto e = errno();
         close(outPipe[0]); close(outPipe[1]);
         close(errPipe[0]); close(errPipe[1]);
+        import errors : clearInflightMarker;
+        clearInflightMarker(sessionId, myPid);
         emitError("exec.fork.script", "fork() failed for script",
                   e, -1, sessionId, controlName, toolUseId, "", "");
         _exit(0);
@@ -385,6 +399,11 @@ void dispatchExec(
     // silently.
     string stdoutData = cast(string) outBuf[0 .. outLen];
     string stderrData = cast(string) errBuf[0 .. errLen];
+    // Clear the inflight marker BEFORE the terminal emit. If deliverError
+    // itself hangs (shouldn't), the marker being gone means the next
+    // hook's scanVanishedWrappers won't false-positive.
+    import errors : clearInflightMarker;
+    clearInflightMarker(sessionId, myPid);
     if (timedOut) {
         emitError("exec.timeout", "grandchild exceeded configured timeout",
                   0, exitCode, sessionId, controlName, toolUseId,

--- a/source/exec_test.d
+++ b/source/exec_test.d
@@ -1,0 +1,46 @@
+module exec_test;
+
+import exec : mergeEnv, MergedEnv;
+
+// mergeEnv layers control-declared env on top of project-declared env.
+// Control wins on collision. Precedence rule from CLAUDE.md-adjacent
+// design: control > project > GROUND_ floor (GROUND_ is prepended at
+// runtime, not by this pure function).
+
+// Both empty → empty result.
+enum MergedEnv empty1 = mergeEnv([], [], [], []);
+static assert(empty1.count == 0);
+
+// Only project → returned unchanged.
+enum MergedEnv onlyProj = mergeEnv([], [], ["port"], ["8770"]);
+static assert(onlyProj.count == 1);
+static assert(onlyProj.keys[0] == "port");
+static assert(onlyProj.values[0] == "8770");
+
+// Only control → returned unchanged.
+enum MergedEnv onlyCtrl = mergeEnv(["target"], ["prod"], [], []);
+static assert(onlyCtrl.count == 1);
+static assert(onlyCtrl.keys[0] == "target");
+static assert(onlyCtrl.values[0] == "prod");
+
+// Disjoint keys → union. Project pairs first (they arrived first), control
+// pairs appended after.
+enum MergedEnv disjoint = mergeEnv(
+    ["target"], ["prod"],
+    ["port"], ["8770"],
+);
+static assert(disjoint.count == 2);
+static assert(disjoint.keys[0] == "port");
+static assert(disjoint.values[0] == "8770");
+static assert(disjoint.keys[1] == "target");
+static assert(disjoint.values[1] == "prod");
+
+// Collision → control's value overwrites project's, position stays where
+// project put it. count does not grow.
+enum MergedEnv collision = mergeEnv(
+    ["port"], ["9999"],
+    ["port"], ["8770"],
+);
+static assert(collision.count == 1);
+static assert(collision.keys[0] == "port");
+static assert(collision.values[0] == "9999");

--- a/source/exec_test.d
+++ b/source/exec_test.d
@@ -3,44 +3,83 @@ module exec_test;
 import exec : mergeEnv, MergedEnv;
 
 // mergeEnv layers control-declared env on top of project-declared env.
-// Control wins on collision. Precedence rule from CLAUDE.md-adjacent
-// design: control > project > GROUND_ floor (GROUND_ is prepended at
-// runtime, not by this pure function).
+// Control wins on collision. Precedence rule: control > project > GROUND_
+// floor (GROUND_ is prepended at runtime, not by this pure function).
+//
+// Env var keys are UPPER_CASE by convention (they become real env vars in
+// the child process). The parser doesn't enforce this — it's a doc rule.
 
 // Both empty → empty result.
 enum MergedEnv empty1 = mergeEnv([], [], [], []);
 static assert(empty1.count == 0);
 
 // Only project → returned unchanged.
-enum MergedEnv onlyProj = mergeEnv([], [], ["port"], ["8770"]);
+enum MergedEnv onlyProj = mergeEnv([], [], ["PORT"], ["8770"]);
 static assert(onlyProj.count == 1);
-static assert(onlyProj.keys[0] == "port");
+static assert(onlyProj.keys[0] == "PORT");
 static assert(onlyProj.values[0] == "8770");
 
 // Only control → returned unchanged.
-enum MergedEnv onlyCtrl = mergeEnv(["target"], ["prod"], [], []);
+enum MergedEnv onlyCtrl = mergeEnv(["TARGET"], ["prod"], [], []);
 static assert(onlyCtrl.count == 1);
-static assert(onlyCtrl.keys[0] == "target");
+static assert(onlyCtrl.keys[0] == "TARGET");
 static assert(onlyCtrl.values[0] == "prod");
 
 // Disjoint keys → union. Project pairs first (they arrived first), control
 // pairs appended after.
 enum MergedEnv disjoint = mergeEnv(
-    ["target"], ["prod"],
-    ["port"], ["8770"],
+    ["TARGET"], ["prod"],
+    ["PORT"], ["8770"],
 );
 static assert(disjoint.count == 2);
-static assert(disjoint.keys[0] == "port");
+static assert(disjoint.keys[0] == "PORT");
 static assert(disjoint.values[0] == "8770");
-static assert(disjoint.keys[1] == "target");
+static assert(disjoint.keys[1] == "TARGET");
 static assert(disjoint.values[1] == "prod");
 
 // Collision → control's value overwrites project's, position stays where
 // project put it. count does not grow.
 enum MergedEnv collision = mergeEnv(
-    ["port"], ["9999"],
-    ["port"], ["8770"],
+    ["PORT"], ["9999"],
+    ["PORT"], ["8770"],
 );
 static assert(collision.count == 1);
-static assert(collision.keys[0] == "port");
+static assert(collision.keys[0] == "PORT");
 static assert(collision.values[0] == "9999");
+
+// --- prepareChildEnv ---
+// Extends mergeEnv with the GROUND_ floor: session id, cwd, tool input
+// JSON. GROUND_ vars come first (positions 0..2), then merged (project +
+// control) pairs. Never fewer than 3 entries — the floor is guaranteed.
+import exec : prepareChildEnv, ChildEnv;
+
+enum ChildEnv floorOnly = prepareChildEnv(
+    [], [], [], [],
+    "sid-xyz", "/tmp/cwd", "{}"
+);
+static assert(floorOnly.count == 3);
+static assert(floorOnly.keys[0] == "GROUND_SESSION_ID");
+static assert(floorOnly.values[0] == "sid-xyz");
+static assert(floorOnly.keys[1] == "GROUND_CWD");
+static assert(floorOnly.values[1] == "/tmp/cwd");
+static assert(floorOnly.keys[2] == "GROUND_TOOL_INPUT");
+static assert(floorOnly.values[2] == "{}");
+
+// Floor + project env only.
+enum ChildEnv withProj = prepareChildEnv(
+    [], [], ["PORT"], ["8770"],
+    "s", "/c", "in"
+);
+static assert(withProj.count == 4);
+static assert(withProj.keys[3] == "PORT");
+static assert(withProj.values[3] == "8770");
+
+// Floor + control env, collision with project (control still wins).
+enum ChildEnv withMerge = prepareChildEnv(
+    ["PORT"], ["9999"],
+    ["PORT"], ["8770"],
+    "s", "/c", "in"
+);
+static assert(withMerge.count == 4);
+static assert(withMerge.keys[3] == "PORT");
+static assert(withMerge.values[3] == "9999");

--- a/source/hooks.d
+++ b/source/hooks.d
@@ -203,6 +203,9 @@ struct Control {
     string[8] paramKeys;
     string[8] paramValues;
     ubyte paramCount;
+    string[8] envKeys;
+    string[8] envValues;
+    ubyte envCount;
     string exec;
     size_t stropIdx; // 0 = no strop; else 1-based index into controls.globalStropPool.
     int interval; // minimum seconds between fires (0 = no limit)

--- a/source/hooks.d
+++ b/source/hooks.d
@@ -203,6 +203,7 @@ struct Control {
     string[8] paramKeys;
     string[8] paramValues;
     ubyte paramCount;
+    string exec;
     size_t stropIdx; // 0 = no strop; else 1-based index into controls.globalStropPool.
     int interval; // minimum seconds between fires (0 = no limit)
 }

--- a/source/immediate.d
+++ b/source/immediate.d
@@ -154,7 +154,25 @@ ImmediateMsg readImmediateMessage(sqlite3* db, const(char)[] cwd, const(char)[] 
         size_t nLen = nameEnd - nameStart;
         if (nLen > nameBuf.length) nLen = nameBuf.length;
         foreach (i; 0 .. nLen) nameBuf[i] = name[i];
-        foreach (i; 0 .. mLen) msgBuf[i] = attrs[mPos + i];
+
+        // Unescape JSON string escapes while copying — the JSON stored in
+        // attributes has \n / \t / \" as literal two-char sequences; watch
+        // delivers via fwrite which needs actual bytes, not escape text.
+        size_t outLen = 0;
+        size_t j = 0;
+        while (j < mLen && outLen < msgBuf.length) {
+            if (j + 1 < mLen && attrs[mPos + j] == '\\') {
+                char nx = attrs[mPos + j + 1];
+                if (nx == 'n')  { msgBuf[outLen++] = '\n'; j += 2; continue; }
+                if (nx == 't')  { msgBuf[outLen++] = '\t'; j += 2; continue; }
+                if (nx == 'r')  { msgBuf[outLen++] = '\r'; j += 2; continue; }
+                if (nx == '"')  { msgBuf[outLen++] = '"';  j += 2; continue; }
+                if (nx == '\\') { msgBuf[outLen++] = '\\'; j += 2; continue; }
+            }
+            msgBuf[outLen++] = attrs[mPos + j];
+            j++;
+        }
+        mLen = outLen;
 
         // Project context for delivery receipt — only set when project-matched.
         // Session-matched rows leave it empty; the session itself is recorded
@@ -503,6 +521,102 @@ void writeCIStatus(sqlite3* db, const(char)[] sessionId,
     sqlite3_bind_text(delStmt, 1, delPred.ptr(), cast(int) delPred.len, SQLITE_TRANSIENT);
     sqlite3_step(delStmt);
     sqlite3_finalize(delStmt);
+}
+
+// Write an immediate:exec-complete message for THIS session.
+// Session-keyed; ID uses time(null) so each fire gets its own row rather
+// than overwriting the previous one. Detail carries the control name,
+// exit code, and captured stdout.
+void writeExecComplete(sqlite3* db,
+                       const(char)[] sessionId,
+                       const(char)[] controlName,
+                       int exitCode,
+                       const(char)[] capturedStdout) {
+    import db : formatTimestamp, versionString;
+
+    if (sessionId.length == 0) return;
+
+    auto now = cast(long) time(null);
+
+    void putLong(ref ZBuf buf, long v) {
+        char[20] tbuf = 0;
+        int tlen = 0;
+        bool neg = v < 0;
+        if (neg) v = -v;
+        if (v == 0) { tbuf[0] = '0'; tlen = 1; }
+        else {
+            while (v > 0 && tlen < 19) { tbuf[tlen++] = cast(char)('0' + v % 10); v /= 10; }
+            foreach (i; 0 .. tlen / 2) { auto tmp = tbuf[i]; tbuf[i] = tbuf[tlen - 1 - i]; tbuf[tlen - 1 - i] = tmp; }
+        }
+        if (neg) buf.put("-");
+        buf.put(tbuf[0 .. tlen]);
+    }
+
+    __gshared ZBuf idBuf;
+    idBuf.reset();
+    idBuf.put("immediate:exec-complete:");
+    idBuf.put(sessionId);
+    idBuf.put(":");
+    idBuf.put(controlName);
+    idBuf.put(":");
+    putLong(idBuf, now);
+
+    __gshared ZBuf predBuf;
+    predBuf.reset();
+    predBuf.put(`["immediate:exec-complete"]`);
+
+    __gshared ZBuf ctxBuf;
+    ctxBuf.reset();
+    ctxBuf.put(`["session:`);
+    ctxBuf.put(sessionId);
+    ctxBuf.put(`"]`);
+
+    void putEscaped(ref ZBuf buf, const(char)[] s) {
+        foreach (c; s) {
+            if (c == '"') buf.put(`\"`);
+            else if (c == '\\') buf.put(`\\`);
+            else if (c == '\n') buf.put(`\n`);
+            else if (c == '\r') buf.put(`\r`);
+            else if (c == '\t') buf.put(`\t`);
+            else if (c < 0x20) continue;
+            else buf.putChar(c);
+        }
+    }
+
+    __gshared ZBuf attrBuf;
+    attrBuf.reset();
+    attrBuf.put(`{"detail":"exec `);
+    putEscaped(attrBuf, controlName);
+    attrBuf.put(` finished (exit `);
+    putLong(attrBuf, cast(long) exitCode);
+    attrBuf.put(`)`);
+    if (capturedStdout.length > 0) {
+        attrBuf.put(`\n`);
+        putEscaped(attrBuf, capturedStdout);
+    }
+    attrBuf.put(`","after":0}`);
+
+    auto ts = formatTimestamp();
+
+    __gshared ZBuf srcBuf;
+    srcBuf.reset();
+    srcBuf.put("ground ");
+    srcBuf.put(versionString());
+
+    enum sql = "INSERT OR REPLACE INTO attestations (id, subjects, predicates, contexts, actors, timestamp, source, attributes) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)\0";
+    sqlite3_stmt* stmt;
+    if (sqlite3_prepare_v2(db, sql.ptr, -1, &stmt, null) != SQLITE_OK)
+        return;
+    sqlite3_bind_text(stmt, 1, idBuf.ptr(), cast(int) idBuf.len, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 2, `["exec"]`.ptr, 8, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 3, predBuf.ptr(), cast(int) predBuf.len, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 4, ctxBuf.ptr(), cast(int) ctxBuf.len, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 5, `["ground"]`.ptr, 10, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 6, ts.ptr, cast(int) ts.length, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 7, srcBuf.ptr(), cast(int) srcBuf.len, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 8, attrBuf.ptr(), cast(int) attrBuf.len, SQLITE_TRANSIENT);
+    sqlite3_step(stmt);
+    sqlite3_finalize(stmt);
 }
 
 // --- Tests ---

--- a/source/immediate.d
+++ b/source/immediate.d
@@ -28,6 +28,8 @@ import db : sqlite3, sqlite3_stmt, sqlite3_prepare_v2, sqlite3_bind_text,
                 ZBuf, jsonArray1, formatTimestamp, versionString, attestEvent;
 import core.stdc.time : time;
 
+extern (C) uint usleep(uint);
+
 struct ImmediateMsg {
     const(char)[] msgId;
     const(char)[] name;
@@ -523,18 +525,26 @@ void writeCIStatus(sqlite3* db, const(char)[] sessionId,
     sqlite3_finalize(delStmt);
 }
 
-// Write an immediate:exec-complete message for THIS session.
-// Session-keyed; ID uses time(null) so each fire gets its own row rather
-// than overwriting the previous one. Detail carries the control name,
-// exit code, and captured stdout.
-void writeExecComplete(sqlite3* db,
-                       const(char)[] sessionId,
-                       const(char)[] controlName,
-                       int exitCode,
-                       const(char)[] capturedStdout) {
-    import db : formatTimestamp, versionString;
+// Write an immediate:exec-result message for THIS session — the single
+// writer for every exec outcome (happy, non-zero exit, start-failed,
+// timed-out). Preserves BOTH stdout and stderr in the delivered detail
+// so no captured content is dropped.
+//
+// Returns true if the row was persisted (INSERT OR REPLACE completed),
+// false otherwise. Retries on SQLITE_BUSY up to 10 times with 50ms
+// spacing (so contention with the ground main hook or other wrappers
+// doesn't silently drop rows). Caller inspects the return and — if
+// false — must escalate to a fallback delivery channel. Per the
+// axiom, silent failure at this layer is forbidden.
+bool writeExecResult(sqlite3* db,
+                     const(char)[] sessionId,
+                     const(char)[] controlName,
+                     const(char)[] result,
+                     const(char)[] stdoutData,
+                     const(char)[] stderrData) {
+    import db : formatTimestamp, versionString, SQLITE_BUSY, SQLITE_DONE;
 
-    if (sessionId.length == 0) return;
+    if (sessionId.length == 0) return false;
 
     auto now = cast(long) time(null);
 
@@ -552,25 +562,6 @@ void writeExecComplete(sqlite3* db,
         buf.put(tbuf[0 .. tlen]);
     }
 
-    __gshared ZBuf idBuf;
-    idBuf.reset();
-    idBuf.put("immediate:exec-complete:");
-    idBuf.put(sessionId);
-    idBuf.put(":");
-    idBuf.put(controlName);
-    idBuf.put(":");
-    putLong(idBuf, now);
-
-    __gshared ZBuf predBuf;
-    predBuf.reset();
-    predBuf.put(`["immediate:exec-complete"]`);
-
-    __gshared ZBuf ctxBuf;
-    ctxBuf.reset();
-    ctxBuf.put(`["session:`);
-    ctxBuf.put(sessionId);
-    ctxBuf.put(`"]`);
-
     void putEscaped(ref ZBuf buf, const(char)[] s) {
         foreach (c; s) {
             if (c == '"') buf.put(`\"`);
@@ -583,16 +574,39 @@ void writeExecComplete(sqlite3* db,
         }
     }
 
+    __gshared ZBuf idBuf;
+    idBuf.reset();
+    idBuf.put("immediate:exec-result:");
+    idBuf.put(sessionId);
+    idBuf.put(":");
+    idBuf.put(controlName);
+    idBuf.put(":");
+    putLong(idBuf, now);
+
+    __gshared ZBuf predBuf;
+    predBuf.reset();
+    predBuf.put(`["immediate:exec-result"]`);
+
+    __gshared ZBuf ctxBuf;
+    ctxBuf.reset();
+    ctxBuf.put(`["session:`);
+    ctxBuf.put(sessionId);
+    ctxBuf.put(`"]`);
+
     __gshared ZBuf attrBuf;
     attrBuf.reset();
     attrBuf.put(`{"detail":"exec `);
     putEscaped(attrBuf, controlName);
-    attrBuf.put(` finished (exit `);
-    putLong(attrBuf, cast(long) exitCode);
-    attrBuf.put(`)`);
-    if (capturedStdout.length > 0) {
-        attrBuf.put(`\n`);
-        putEscaped(attrBuf, capturedStdout);
+    attrBuf.put(`: `);
+    putEscaped(attrBuf, result);
+    // Preserve BOTH streams. Label so the reader can tell them apart.
+    if (stdoutData.length > 0) {
+        attrBuf.put(`\nstdout:\n`);
+        putEscaped(attrBuf, stdoutData);
+    }
+    if (stderrData.length > 0) {
+        attrBuf.put(`\nstderr:\n`);
+        putEscaped(attrBuf, stderrData);
     }
     attrBuf.put(`","after":0}`);
 
@@ -604,19 +618,39 @@ void writeExecComplete(sqlite3* db,
     srcBuf.put(versionString());
 
     enum sql = "INSERT OR REPLACE INTO attestations (id, subjects, predicates, contexts, actors, timestamp, source, attributes) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)\0";
-    sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2(db, sql.ptr, -1, &stmt, null) != SQLITE_OK)
-        return;
-    sqlite3_bind_text(stmt, 1, idBuf.ptr(), cast(int) idBuf.len, SQLITE_TRANSIENT);
-    sqlite3_bind_text(stmt, 2, `["exec"]`.ptr, 8, SQLITE_TRANSIENT);
-    sqlite3_bind_text(stmt, 3, predBuf.ptr(), cast(int) predBuf.len, SQLITE_TRANSIENT);
-    sqlite3_bind_text(stmt, 4, ctxBuf.ptr(), cast(int) ctxBuf.len, SQLITE_TRANSIENT);
-    sqlite3_bind_text(stmt, 5, `["ground"]`.ptr, 10, SQLITE_TRANSIENT);
-    sqlite3_bind_text(stmt, 6, ts.ptr, cast(int) ts.length, SQLITE_TRANSIENT);
-    sqlite3_bind_text(stmt, 7, srcBuf.ptr(), cast(int) srcBuf.len, SQLITE_TRANSIENT);
-    sqlite3_bind_text(stmt, 8, attrBuf.ptr(), cast(int) attrBuf.len, SQLITE_TRANSIENT);
-    sqlite3_step(stmt);
-    sqlite3_finalize(stmt);
+
+    enum RETRY_LIMIT = 10;
+    enum RETRY_SLEEP_US = 50_000; // 50ms
+
+    foreach (attempt; 0 .. RETRY_LIMIT) {
+        sqlite3_stmt* stmt;
+        auto prep = sqlite3_prepare_v2(db, sql.ptr, -1, &stmt, null);
+        if (prep == SQLITE_BUSY) {
+            usleep(RETRY_SLEEP_US);
+            continue;
+        }
+        if (prep != SQLITE_OK) return false;
+
+        sqlite3_bind_text(stmt, 1, idBuf.ptr(), cast(int) idBuf.len, SQLITE_TRANSIENT);
+        sqlite3_bind_text(stmt, 2, `["exec"]`.ptr, 8, SQLITE_TRANSIENT);
+        sqlite3_bind_text(stmt, 3, predBuf.ptr(), cast(int) predBuf.len, SQLITE_TRANSIENT);
+        sqlite3_bind_text(stmt, 4, ctxBuf.ptr(), cast(int) ctxBuf.len, SQLITE_TRANSIENT);
+        sqlite3_bind_text(stmt, 5, `["ground"]`.ptr, 10, SQLITE_TRANSIENT);
+        sqlite3_bind_text(stmt, 6, ts.ptr, cast(int) ts.length, SQLITE_TRANSIENT);
+        sqlite3_bind_text(stmt, 7, srcBuf.ptr(), cast(int) srcBuf.len, SQLITE_TRANSIENT);
+        sqlite3_bind_text(stmt, 8, attrBuf.ptr(), cast(int) attrBuf.len, SQLITE_TRANSIENT);
+
+        auto step = sqlite3_step(stmt);
+        sqlite3_finalize(stmt);
+
+        if (step == SQLITE_DONE) return true;
+        if (step == SQLITE_BUSY) {
+            usleep(RETRY_SLEEP_US);
+            continue;
+        }
+        return false; // non-busy step error — caller escalates
+    }
+    return false; // retries exhausted — caller escalates
 }
 
 // --- Tests ---

--- a/source/immediate.d
+++ b/source/immediate.d
@@ -653,6 +653,34 @@ bool writeExecResult(sqlite3* db,
     return false; // retries exhausted — caller escalates
 }
 
+// Count immediate:* rows for THIS session that have no matching
+// delivered:<msgId> receipt. Used by errors.checkImmediateBacklog to
+// detect a broken delivery pipeline (watch dead but rows accumulating).
+//
+// Returns 0 on any prepare/step failure — we don't want to false-alarm
+// on transient sqlite trouble; the wrapper's own retries handle that.
+long countPendingImmediateForSession(sqlite3* db, const(char)[] sessionId) {
+    if (sessionId.length == 0) return 0;
+
+    enum sql = "SELECT COUNT(*) FROM attestations a WHERE json_extract(a.predicates,'$[0]') >= 'immediate:' AND json_extract(a.predicates,'$[0]') < 'immediate;' AND a.contexts LIKE ?1 AND NOT EXISTS (SELECT 1 FROM attestations d WHERE json_extract(d.predicates,'$[0]') = 'delivered:' || a.id AND d.contexts LIKE ?1)\0";
+
+    __gshared ZBuf pattern;
+    pattern.reset();
+    pattern.put(`%session:`);
+    pattern.put(sessionId);
+    pattern.put(`%`);
+
+    sqlite3_stmt* stmt;
+    if (sqlite3_prepare_v2(db, sql.ptr, -1, &stmt, null) != SQLITE_OK) return 0;
+    sqlite3_bind_text(stmt, 1, pattern.ptr(), cast(int) pattern.len, SQLITE_TRANSIENT);
+
+    long n = 0;
+    import db : sqlite3_column_int64, SQLITE_ROW;
+    if (sqlite3_step(stmt) == SQLITE_ROW) n = sqlite3_column_int64(stmt, 0);
+    sqlite3_finalize(stmt);
+    return n;
+}
+
 // --- Tests ---
 
 unittest {

--- a/source/posttooluse.d
+++ b/source/posttooluse.d
@@ -83,6 +83,33 @@ int handlePostToolUse(const(char)[] input, const(char)[] cwd, const(char)[] sess
 
     auto tParse = usecNow();
 
+    // Exec dispatch — fire and forget. Any matched PostToolUse control
+    // with exec: set spawns a detached child. Runs before the msg pass so
+    // the msg pass's return-on-first-match doesn't skip exec fires.
+    {
+        import controls : postToolUseScopes;
+        import exec : dispatchExec;
+        foreach (ref sc; postToolUseScopes) {
+            if (!scopeMatches(sc, cwd)) continue;
+            foreach (ref c; sc.controls) {
+                if (c.exec.length == 0) continue;
+                if (!postToolUseMatch(c, detail, filePath, toolName)) continue;
+                if (c.pushedPath.value.length > 0) {
+                    import control_handlers : pushedFiles;
+                    import push : hasPathStartingWith;
+                    if (!hasPathStartingWith(pushedFiles(cwd), c.pushedPath.value))
+                        continue;
+                }
+                dispatchExec(
+                    c.exec,
+                    c.envKeys[0 .. c.envCount],
+                    c.envValues[0 .. c.envCount],
+                    cast(string) sessionId, cwd, input,
+                );
+            }
+        }
+    }
+
     // Check PostToolUse controls (msg-only fire once per session)
     {
         import controls : postToolUseScopes;

--- a/source/posttooluse.d
+++ b/source/posttooluse.d
@@ -123,9 +123,26 @@ int handlePostToolUse(const(char)[] input, const(char)[] cwd, const(char)[] sess
                     continue;
                 if (edb !is null && toolUseId.length > 0)
                     attestExecFire(edb, c.name, cwd, sessionId, toolUseId);
+                // Read timeout_sec from control's handler_params, if any.
+                // Zero means "use dispatchExec's default (DEFAULT_TIMEOUT_SEC)".
+                int timeoutSec = 0;
+                foreach (i; 0 .. c.paramCount) {
+                    if (c.paramKeys[i] == "timeout_sec") {
+                        // parse int
+                        int n = 0;
+                        foreach (ch; c.paramValues[i]) {
+                            if (ch < '0' || ch > '9') { n = 0; break; }
+                            n = n * 10 + (ch - '0');
+                        }
+                        timeoutSec = n;
+                        break;
+                    }
+                }
                 dispatchExec(
                     c.exec,
                     c.name,
+                    cast(string) toolUseId,
+                    timeoutSec,
                     c.envKeys[0 .. c.envCount],
                     c.envValues[0 .. c.envCount],
                     cast(string) sessionId, cwd, input,

--- a/source/posttooluse.d
+++ b/source/posttooluse.d
@@ -102,6 +102,7 @@ int handlePostToolUse(const(char)[] input, const(char)[] cwd, const(char)[] sess
                 }
                 dispatchExec(
                     c.exec,
+                    c.name,
                     c.envKeys[0 .. c.envCount],
                     c.envValues[0 .. c.envCount],
                     cast(string) sessionId, cwd, input,

--- a/source/posttooluse.d
+++ b/source/posttooluse.d
@@ -83,14 +83,32 @@ int handlePostToolUse(const(char)[] input, const(char)[] cwd, const(char)[] sess
 
     auto tParse = usecNow();
 
-    // Exec dispatch — fire and forget. Any matched PostToolUse control
-    // with exec: set spawns a detached child. Runs before the msg pass so
-    // the msg pass's return-on-first-match doesn't skip exec fires.
+    // Exec dispatch — two safety checks alongside the control-cmd match:
+    //
+    //   Scope-cmd: scope-level cmd is not propagated to Control.cmd for
+    //   non-strop controls (proto.d:219-228), so postToolUseMatch alone
+    //   would let a control with no cmd of its own fire on every tool
+    //   call in the scope. Enforce sc.cmds explicitly here.
+    //
+    //   tool_use_id dedup: GroundedExec attestation with tool_use_id in
+    //   attributes. Any repeated PostToolUse invocation for the same
+    //   tool call finds the attestation and skips.
+    import parse : extractToolUseId;
+    auto toolUseId = extractToolUseId(input);
     {
         import controls : postToolUseScopes;
         import exec : dispatchExec;
+        import db : openDb, execFireExists, attestExecFire, sqlite3_close;
+        auto edb = openDb();
         foreach (ref sc; postToolUseScopes) {
             if (!scopeMatches(sc, cwd)) continue;
+            if (sc.cmdCount > 0) {
+                bool scopeCmdMatched = false;
+                foreach (i; 0 .. sc.cmdCount) {
+                    if (hasSegment(detail, sc.cmds[i])) { scopeCmdMatched = true; break; }
+                }
+                if (!scopeCmdMatched) continue;
+            }
             foreach (ref c; sc.controls) {
                 if (c.exec.length == 0) continue;
                 if (!postToolUseMatch(c, detail, filePath, toolName)) continue;
@@ -100,6 +118,11 @@ int handlePostToolUse(const(char)[] input, const(char)[] cwd, const(char)[] sess
                     if (!hasPathStartingWith(pushedFiles(cwd), c.pushedPath.value))
                         continue;
                 }
+                if (edb !is null && toolUseId.length > 0
+                    && execFireExists(edb, c.name, sessionId, toolUseId))
+                    continue;
+                if (edb !is null && toolUseId.length > 0)
+                    attestExecFire(edb, c.name, cwd, sessionId, toolUseId);
                 dispatchExec(
                     c.exec,
                     c.name,
@@ -109,6 +132,7 @@ int handlePostToolUse(const(char)[] input, const(char)[] cwd, const(char)[] sess
                 );
             }
         }
+        if (edb !is null) sqlite3_close(edb);
     }
 
     // Check PostToolUse controls (msg-only fire once per session)

--- a/source/posttooluse.d
+++ b/source/posttooluse.d
@@ -76,6 +76,15 @@ int handlePostToolUse(const(char)[] input, const(char)[] cwd, const(char)[] sess
     import main : usecNow;
     auto t0 = usecNow();
 
+    // ERROR AXIOM: catch wrapper processes that died before delivering.
+    // Scans this session's inflight markers; any older than
+    // startTs+timeoutSec+GRACE_SEC emits exec.wrapper.vanished via
+    // deliverError and unlinks the marker.
+    {
+        import errors : scanVanishedWrappers;
+        scanVanishedWrappers(cast(string) sessionId);
+    }
+
     auto command = extractCommand(input);
     auto filePath = extractFilePath(input);
     auto toolName = extractToolName(input);

--- a/source/posttooluse.d
+++ b/source/posttooluse.d
@@ -81,8 +81,13 @@ int handlePostToolUse(const(char)[] input, const(char)[] cwd, const(char)[] sess
     // startTs+timeoutSec+GRACE_SEC emits exec.wrapper.vanished via
     // deliverError and unlinks the marker.
     {
-        import errors : scanVanishedWrappers;
+        import errors : scanVanishedWrappers, writeImmediateBacklogStderr;
         scanVanishedWrappers(cast(string) sessionId);
+        // Delivery-pipeline health: watch daemon dead + rows pending →
+        // stderr + breadcrumb. Point-of-interaction surfacing happens at
+        // Stop (see handleStop's exit) since that's where writeStopResponse
+        // can prepend the warning to a Stop reason.
+        writeImmediateBacklogStderr(cast(string) sessionId);
     }
 
     auto command = extractCommand(input);

--- a/source/proto.d
+++ b/source/proto.d
@@ -53,6 +53,9 @@ struct ParsedControl {
     string[8] paramKeys;
     string[8] paramValues;
     ubyte paramCount;
+    string[8] envKeys;
+    string[8] envValues;
+    ubyte envCount;
     size_t stropIdx; // 0 = no strop; else 1-based index into ParseResult.stropPool.
 }
 
@@ -257,6 +260,12 @@ ScopeSet buildScopes(
                 c.paramKeys = pc.paramKeys;
                 c.paramValues = pc.paramValues;
                 c.paramCount = pc.paramCount;
+            }
+
+            if (pc.envCount > 0) {
+                c.envKeys = pc.envKeys;
+                c.envValues = pc.envValues;
+                c.envCount = pc.envCount;
             }
 
             c.exec = pc.exec;
@@ -702,6 +711,28 @@ void parseHandlerParamsBlock(ref string input, ref size_t pos,
     assert(0, "Unterminated handler_params block");
 }
 
+void parseControlEnvBlock(ref string input, ref size_t pos,
+    ref string[8] keys, ref string[8] values, ref ubyte count)
+{
+    while (pos < input.length) {
+        skipWS(input, pos);
+        if (pos >= input.length) break;
+        if (input[pos] == '#') { skipLine(input, pos); continue; }
+        if (input[pos] == '}') { pos++; return; }
+
+        auto key = readWord(input, pos);
+        skipWS(input, pos);
+        expect(input, pos, ':');
+        skipWS(input, pos);
+        auto val = readValue(input, pos);
+        assert(count < 8, "control env: too many pairs (max 8)");
+        keys[count] = key;
+        values[count] = val;
+        count++;
+    }
+    assert(0, "Unterminated control env block");
+}
+
 public ParsedControl parseControl(ref string input, ref size_t pos, ref ParseResult result) {
     ParsedControl c;
     while (pos < input.length) {
@@ -726,6 +757,12 @@ public ParsedControl parseControl(ref string input, ref size_t pos, ref ParseRes
         if (key == "handler_params") {
             expect(input, pos, '{');
             parseHandlerParamsBlock(input, pos, c.paramKeys, c.paramValues, c.paramCount);
+            continue;
+        }
+
+        if (key == "env") {
+            expect(input, pos, '{');
+            parseControlEnvBlock(input, pos, c.envKeys, c.envValues, c.envCount);
             continue;
         }
 

--- a/source/proto.d
+++ b/source/proto.d
@@ -39,7 +39,7 @@ struct ParsedControl {
     string arg, omit, omitLine, clamp;
     string[16] triggers;
     ubyte triggerCount;
-    string filepath, msg, mcpArg, pushedPath;
+    string filepath, msg, mcpArg, pushedPath, exec;
     string[8] contents;
     ubyte contentCount;
     string[8] userprompts;
@@ -790,6 +790,7 @@ public ParsedControl parseControl(ref string input, ref size_t pos, ref ParseRes
             case "bg":              c.bg = (val == "true"); break;
             case "tmo":             c.tmo = parseInt(val); break;
             case "check_handler":   c.checkHandler = val; break;
+            case "exec":            c.exec = val; break;
             case "pushed_paths":    c.pushedPath = val; break;
             case "delay_handler":   c.delayHandler = val; break;
             case "deliver_handler": c.deliverHandler = val; break;

--- a/source/proto.d
+++ b/source/proto.d
@@ -259,6 +259,8 @@ ScopeSet buildScopes(
                 c.paramCount = pc.paramCount;
             }
 
+            c.exec = pc.exec;
+
             if (pc.deliverHandler.length > 0 && ps.event == "SessionStart") {
                 auto dfn = resolveDeliver(pc.deliverHandler);
                 assert(dfn !is null);

--- a/source/proto_exec_test.d
+++ b/source/proto_exec_test.d
@@ -1,0 +1,43 @@
+module proto_exec_test;
+
+import proto : parsePbt;
+import proto_test : ctrl;
+
+// > "I have a hook system. I could run code always after you do a push
+// > automatically in the QNTX repo."
+//
+// > "We could extend ground to run specified .fish files on certain
+// > event cwd matches, inside of the claude code session, and report
+// > back when it's completed via ground watch."
+//
+// > "I do want exec."
+//
+// > "Yeah, just don't be fucking stupid about what you put in the exec
+// > scripts."
+//
+// The control this was designed for:
+//
+//   scope {
+//     path: "/QNTX"
+//     event: "PostToolUse"
+//     cmd: "git push"
+//     control {
+//       name: "q-web-deploy-on-push"
+//       exec: "<path-to-deploy-q-web.fish>"
+//     }
+//   }
+
+enum execInput = `
+scope {
+  path: "/QNTX"
+  event: "PostToolUse"
+  cmd: "git push"
+  control {
+    name: "q-web-deploy-on-push"
+    exec: "/tmp/deploy-q-web.fish"
+  }
+}
+`;
+enum execParsed = parsePbt(execInput);
+static assert(ctrl(execParsed, 0, 0).name == "q-web-deploy-on-push");
+static assert(ctrl(execParsed, 0, 0).exec == "/tmp/deploy-q-web.fish");

--- a/source/proto_exec_test.d
+++ b/source/proto_exec_test.d
@@ -1,6 +1,6 @@
 module proto_exec_test;
 
-import proto : parsePbt;
+import proto : parsePbt, buildScopes;
 import proto_test : ctrl;
 
 // > "I have a hook system. I could run code always after you do a push
@@ -41,3 +41,7 @@ scope {
 enum execParsed = parsePbt(execInput);
 static assert(ctrl(execParsed, 0, 0).name == "q-web-deploy-on-push");
 static assert(ctrl(execParsed, 0, 0).exec == "/tmp/deploy-q-web.fish");
+
+// buildScopes wires exec through to the runtime Control struct.
+enum execBuilt = buildScopes(execParsed, "PostToolUse");
+static assert(execBuilt.items[0].controls[0].exec == "/tmp/deploy-q-web.fish");

--- a/source/proto_exec_test.d
+++ b/source/proto_exec_test.d
@@ -15,7 +15,9 @@ import proto_test : ctrl;
 // > "Yeah, just don't be fucking stupid about what you put in the exec
 // > scripts."
 //
-// The control this was designed for:
+// The control this was designed for (inline form — script content lives
+// in the pbt, not at a filesystem path. See "or is it a security thing?"
+// design decision.):
 //
 //   scope {
 //     path: "/QNTX"
@@ -23,28 +25,33 @@ import proto_test : ctrl;
 //     cmd: "git push"
 //     control {
 //       name: "q-web-deploy-on-push"
-//       exec: "<path-to-deploy-q-web.fish>"
+//       exec: `
+//         #!/usr/bin/env fish
+//         # deploy body
+//       `
 //     }
 //   }
 
-enum execInput = `
+enum execInput = "
 scope {
-  path: "/QNTX"
-  event: "PostToolUse"
-  cmd: "git push"
+  path: \"/QNTX\"
+  event: \"PostToolUse\"
+  cmd: \"git push\"
   control {
-    name: "q-web-deploy-on-push"
-    exec: "/tmp/deploy-q-web.fish"
+    name: \"q-web-deploy-on-push\"
+    exec: `#!/usr/bin/env fish
+echo deploying
+`
   }
 }
-`;
+";
 enum execParsed = parsePbt(execInput);
 static assert(ctrl(execParsed, 0, 0).name == "q-web-deploy-on-push");
-static assert(ctrl(execParsed, 0, 0).exec == "/tmp/deploy-q-web.fish");
+static assert(ctrl(execParsed, 0, 0).exec == "#!/usr/bin/env fish\necho deploying\n");
 
 // buildScopes wires exec through to the runtime Control struct.
 enum execBuilt = buildScopes(execParsed, "PostToolUse");
-static assert(execBuilt.items[0].controls[0].exec == "/tmp/deploy-q-web.fish");
+static assert(execBuilt.items[0].controls[0].exec == "#!/usr/bin/env fish\necho deploying\n");
 
 // Control-level env { } block — the pbt-declarative way to configure the
 // exec child. Same block shape as `project { env { … } }`, but attached to

--- a/source/proto_exec_test.d
+++ b/source/proto_exec_test.d
@@ -45,3 +45,34 @@ static assert(ctrl(execParsed, 0, 0).exec == "/tmp/deploy-q-web.fish");
 // buildScopes wires exec through to the runtime Control struct.
 enum execBuilt = buildScopes(execParsed, "PostToolUse");
 static assert(execBuilt.items[0].controls[0].exec == "/tmp/deploy-q-web.fish");
+
+// Control-level env { } block — the pbt-declarative way to configure the
+// exec child. Same block shape as `project { env { … } }`, but attached to
+// a control. Reads at exec-fire time; the child sees these as env vars.
+enum execWithEnvInput = `
+scope {
+  path: "/QNTX"
+  event: "PostToolUse"
+  cmd: "git push"
+  control {
+    name: "q-web-deploy-on-push"
+    exec: "/tmp/deploy-q-web.fish"
+    env {
+      target: "production"
+      api_key_var: "PROD_KEY"
+    }
+  }
+}
+`;
+enum execWithEnvParsed = parsePbt(execWithEnvInput);
+static assert(ctrl(execWithEnvParsed, 0, 0).envCount == 2);
+static assert(ctrl(execWithEnvParsed, 0, 0).envKeys[0] == "target");
+static assert(ctrl(execWithEnvParsed, 0, 0).envValues[0] == "production");
+static assert(ctrl(execWithEnvParsed, 0, 0).envKeys[1] == "api_key_var");
+static assert(ctrl(execWithEnvParsed, 0, 0).envValues[1] == "PROD_KEY");
+
+// buildScopes carries env through to runtime Control.
+enum execWithEnvBuilt = buildScopes(execWithEnvParsed, "PostToolUse");
+static assert(execWithEnvBuilt.items[0].controls[0].envCount == 2);
+static assert(execWithEnvBuilt.items[0].controls[0].envKeys[0] == "target");
+static assert(execWithEnvBuilt.items[0].controls[0].envValues[0] == "production");

--- a/source/proto_test.d
+++ b/source/proto_test.d
@@ -1,5 +1,7 @@
 module proto_test;
 
+// TODO: split by feature area — see proto_exec_test.d for the pattern (one focused file per pbt feature).
+
 import proto : parsePbt, buildScopes, ParseResult;
 import hooks : CheckFn, DelayFn, DeliverFn;
 
@@ -928,3 +930,4 @@ enum handlerParamsBuilt = buildScopes!(stubResolveCheck)(handlerParamsParsed, "P
 static assert(handlerParamsBuilt.items[0].controls[0].paramCount == 1);
 static assert(handlerParamsBuilt.items[0].controls[0].paramKeys[0] == "depth");
 static assert(handlerParamsBuilt.items[0].controls[0].paramValues[0] == "4");
+

--- a/source/stop.d
+++ b/source/stop.d
@@ -111,6 +111,14 @@ int handleStop(const(char)[] input, const(char)[] cwd, const(char)[] sessionId) 
         writeWatchClaim(sessionId);
     }
 
+    // ERROR AXIOM: catch wrapper processes that died before delivering.
+    // Stop is a reliable scan point since it fires at end of every session
+    // turn — even if PostToolUse missed the wrapper-vanished case earlier.
+    if (sessionId !is null) {
+        import errors : scanVanishedWrappers;
+        scanVanishedWrappers(cast(string) sessionId);
+    }
+
     auto hookActive = extractBool(input, `"stop_hook_active"`);
 
     if (hookActive)

--- a/source/stop.d
+++ b/source/stop.d
@@ -341,7 +341,7 @@ int handleStop(const(char)[] input, const(char)[] cwd, const(char)[] sessionId) 
             struct Budget { string event; long thresholdUs; }
             static immutable budgets = [
                 Budget("PreToolUse",       50_000),
-                Budget("PostToolUse",     200_000),
+                Budget("PostToolUse",     300_000),
                 Budget("UserPromptSubmit", 50_000),
                 Budget("Stop",            300_000),
                 Budget("SessionStart",  2_000_000),

--- a/source/stop.d
+++ b/source/stop.d
@@ -111,12 +111,23 @@ int handleStop(const(char)[] input, const(char)[] cwd, const(char)[] sessionId) 
         writeWatchClaim(sessionId);
     }
 
-    // ERROR AXIOM: catch wrapper processes that died before delivering.
-    // Stop is a reliable scan point since it fires at end of every session
-    // turn — even if PostToolUse missed the wrapper-vanished case earlier.
+    // ERROR AXIOM: catch wrapper processes that died before delivering,
+    // and check the delivery pipeline itself is alive. Stop runs both since
+    // it's the natural end-of-turn sync point.
     if (sessionId !is null) {
-        import errors : scanVanishedWrappers;
+        import errors : scanVanishedWrappers, immediateBacklogMessage;
         scanVanishedWrappers(cast(string) sessionId);
+        // If the watch daemon is dead and rows are pending, block Stop
+        // with the backlog message. Point of interaction: user sees the
+        // failure at end-of-turn instead of silently missing exec output.
+        // The killSessionWatcher/writeWatchClaim above still ran, and the
+        // asyncRewake config still spawns a new watch — blocking Stop
+        // doesn't prevent recovery on the next turn.
+        auto backlog = immediateBacklogMessage(cast(string) sessionId);
+        if (backlog.length > 0) {
+            writeStopResponseAndNotify(backlog);
+            return 0;
+        }
     }
 
     auto hookActive = extractBool(input, `"stop_hook_active"`);

--- a/source/watch.d
+++ b/source/watch.d
@@ -243,6 +243,40 @@ const(char)[] claimSession(const(char)[] cwd) {
     return null;
 }
 
+// Is the watch daemon alive for this session?
+// True if the pid file exists AND kill(pid, 0) reports the process is alive.
+// A missing pid file returns true so a session that hasn't spawned a watcher
+// yet doesn't false-alarm. Errors during read return true for the same reason.
+// Callers combine with countPendingImmediateForSession to distinguish the
+// benign case (no work anyway) from the real bug (work waiting, no reader).
+bool isWatchAlive(const(char)[] sessionId) {
+    if (sessionId.length == 0) return true;
+
+    __gshared char[512] pathBuf = 0;
+    auto pLen = buildGroundPath(pathBuf, "watch-", sessionId, ".pid");
+    if (pLen == 0) return true;
+
+    auto rf = fopen(&pathBuf[0], "r");
+    if (rf is null) return true;
+
+    char[16] pidBuf = 0;
+    auto n = fread(&pidBuf[0], 1, 15, rf);
+    fclose(rf);
+
+    int pid = 0;
+    foreach (i; 0 .. n) {
+        if (pidBuf[i] >= '0' && pidBuf[i] <= '9')
+            pid = pid * 10 + (pidBuf[i] - '0');
+        else break;
+    }
+    if (pid <= 0) return true;
+
+    // Signal 0 does nothing but performs the pid-lookup + permission check.
+    // Return 0 = alive. Return -1 with ESRCH = dead. Same-user process so
+    // EPERM won't occur.
+    return kill(pid, 0) == 0;
+}
+
 // Write our PID to the session-keyed PID file.
 void writePid(const(char)[] sessionId) {
     __gshared char[512] pathBuf = 0;


### PR DESCRIPTION
## Example

`controls/deploy.pbt`:

    scope {
      path: "/myproject"
      event: "PostToolUse"
      cmd: "git push"

      control {
        name: "deploy"
        exec: `#!/usr/bin/env bash
    ssh prod 'cd /srv/app && git pull && systemctl restart app'
    `
      }
    }

When Claude runs `git push` inside `/myproject`, the script runs and its output is delivered to the session on the next hook cycle via `ground watch`:

    exec deploy: exit 0
    stdout:
    From github.com:me/app
       a1b2c3d..e4f5g6h  main -> main
    Restarted app.service
